### PR TITLE
Rename `DCB*` types with `Dcb*`

### DIFF
--- a/tests-integration/tests/api_key.rs
+++ b/tests-integration/tests/api_key.rs
@@ -5,7 +5,7 @@ use rcgen::generate_simple_self_signed;
 use tempfile::tempdir;
 use tokio::time::sleep;
 use umadb_client::{AsyncUmaDBClient, ClientTlsOptions, UmaDBClient};
-use umadb_dcb::{DdbError, DcbEvent, DcbEventStoreAsync};
+use umadb_dcb::{DcbError, DcbEvent, DcbEventStoreAsync};
 use umadb_server::start_server_secure_with_api_key;
 
 // Helper to pick a free localhost port
@@ -162,7 +162,7 @@ async fn api_key_wrong_fails_over_tls() {
     // Calls should fail with Unauthenticated mapped to TransportError/Io (depending on mapping)
     let err = client.head().await.err().expect("head should fail");
     match err {
-        DdbError::AuthenticationError(_) => {}
+        DcbError::AuthenticationError(_) => {}
         other => panic!("unexpected error type: {:?}", other),
     }
 
@@ -183,7 +183,7 @@ async fn api_key_rejected_over_insecure_http() {
             .err()
             .expect("head must fail due to insecure");
         match err {
-            DdbError::TransportError(msg) => assert!(msg.contains("TLS")),
+            DcbError::TransportError(msg) => assert!(msg.contains("TLS")),
             other => panic!("unexpected error type: {:?}", other),
         }
     }

--- a/tests-integration/tests/api_key.rs
+++ b/tests-integration/tests/api_key.rs
@@ -5,7 +5,7 @@ use rcgen::generate_simple_self_signed;
 use tempfile::tempdir;
 use tokio::time::sleep;
 use umadb_client::{AsyncUmaDBClient, ClientTlsOptions, UmaDBClient};
-use umadb_dcb::{DCBError, DCBEvent, DCBEventStoreAsync};
+use umadb_dcb::{DdbError, DcbEvent, DcbEventStoreAsync};
 use umadb_server::start_server_secure_with_api_key;
 
 // Helper to pick a free localhost port
@@ -83,8 +83,8 @@ async fn api_key_success_over_tls() {
     };
 
     // Append and read should succeed
-    let events: Vec<DCBEvent> = (0..3)
-        .map(|i| DCBEvent {
+    let events: Vec<DcbEvent> = (0..3)
+        .map(|i| DcbEvent {
             event_type: "AuthTest".to_string(),
             data: format!("data-{}", i).into_bytes(),
             tags: vec!["t".to_string()],
@@ -162,7 +162,7 @@ async fn api_key_wrong_fails_over_tls() {
     // Calls should fail with Unauthenticated mapped to TransportError/Io (depending on mapping)
     let err = client.head().await.err().expect("head should fail");
     match err {
-        DCBError::AuthenticationError(_) => {}
+        DdbError::AuthenticationError(_) => {}
         other => panic!("unexpected error type: {:?}", other),
     }
 
@@ -183,7 +183,7 @@ async fn api_key_rejected_over_insecure_http() {
             .err()
             .expect("head must fail due to insecure");
         match err {
-            DCBError::TransportError(msg) => assert!(msg.contains("TLS")),
+            DdbError::TransportError(msg) => assert!(msg.contains("TLS")),
             other => panic!("unexpected error type: {:?}", other),
         }
     }

--- a/tests-integration/tests/client_methods.rs
+++ b/tests-integration/tests/client_methods.rs
@@ -11,7 +11,7 @@ use tonic_health::pb::health_client::HealthClient;
 
 use umadb_client::UmaDBClient;
 use umadb_dcb::{
-    DCBAppendCondition, DCBEvent, DCBEventStoreAsync, DCBEventStoreSync, DCBQuery, DCBQueryItem,
+    DcbAppendCondition, DcbEvent, DcbEventStoreAsync, DcbEventStoreSync, DcbQuery, DcbQueryItem,
 };
 use umadb_server::start_server;
 use uuid::Uuid;
@@ -108,7 +108,7 @@ fn client_sync_covers_all_methods() {
 
     // Prepare some events
     let mk_event = |i: u8| {
-        DCBEvent::default()
+        DcbEvent::default()
             .event_type("ExampleEvent")
             .tags(["tagA", "tagB"])
             .data(vec![i])
@@ -159,7 +159,7 @@ fn client_sync_covers_all_methods() {
     assert_eq!(b2.len(), 1);
 
     // Exercise: read_with_head helper with a boundary and after parameter
-    let boundary = DCBQuery::new().item(DCBQueryItem::new().types(["ExampleEvent"]).tags(["tagA"]));
+    let boundary = DcbQuery::new().item(DcbQueryItem::new().types(["ExampleEvent"]).tags(["tagA"]));
     let (vec_events, head3) = client
         .read_with_head(Some(boundary.clone()), None, false, None)
         .unwrap();
@@ -167,7 +167,7 @@ fn client_sync_covers_all_methods() {
     assert_eq!(head3, Some(p3));
 
     // Now try conditional append using last-known head
-    let cond = DCBAppendCondition::new(boundary).after(head3);
+    let cond = DcbAppendCondition::new(boundary).after(head3);
     let e4 = mk_event(4);
     let p4 = client.append(vec![e4.clone()], Some(cond), None).unwrap();
     assert!(p4 > p3);
@@ -212,7 +212,7 @@ async fn client_async_covers_all_methods() {
 
     // Prepare events
     let mk_event = |i: u8| {
-        DCBEvent::default()
+        DcbEvent::default()
             .event_type("ExampleEvent")
             .tags(["tagA", "tagB"])
             .data(vec![i])
@@ -261,7 +261,7 @@ async fn client_async_covers_all_methods() {
     assert_eq!(head2, Some(p3));
 
     // Use a boundary and conditional append based on head
-    let boundary = DCBQuery::new().item(DCBQueryItem::new().types(["ExampleEvent"]).tags(["tagA"]));
+    let boundary = DcbQuery::new().item(DcbQueryItem::new().types(["ExampleEvent"]).tags(["tagA"]));
     let (evs_in_boundary, head3) = client
         .read_with_head(Some(boundary.clone()), None, false, None)
         .await
@@ -269,7 +269,7 @@ async fn client_async_covers_all_methods() {
     assert_eq!(evs_in_boundary.len(), 3);
     assert_eq!(head3, Some(p3));
 
-    let cond = DCBAppendCondition::new(boundary).after(head3);
+    let cond = DcbAppendCondition::new(boundary).after(head3);
     let p4 = client
         .append(vec![mk_event(4)], Some(cond), None)
         .await

--- a/tests-integration/tests/event_store_test.rs
+++ b/tests-integration/tests/event_store_test.rs
@@ -4,7 +4,7 @@ use tokio::runtime::Builder as RtBuilder;
 use umadb_client::UmaDBClient;
 use umadb_core::db::UmaDB;
 use umadb_dcb::{
-    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem,
+    DcbAppendCondition, DcbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem,
 };
 use umadb_server::start_server;
 use uuid::Uuid;
@@ -683,7 +683,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
     // Fail because condition matches all.
     let new = vec![event4.clone()];
     let result = event_store.append(new.clone(), Some(DcbAppendCondition::default()), None);
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches all after 1.
     let result = event_store.append(
@@ -694,7 +694,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches type1.
     let result = event_store.append(
@@ -705,7 +705,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches type2 after 1.
     let result = event_store.append(
@@ -716,7 +716,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches tagX.
     let result = event_store.append(
@@ -727,7 +727,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches tagA after 1.
     let result = event_store.append(
@@ -738,7 +738,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches type1 and tagX.
     let result = event_store.append(
@@ -749,7 +749,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches type2 and tagA after 1.
     let result = event_store.append(
@@ -760,7 +760,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches tagA and tagB.
     let result = event_store.append(
@@ -771,7 +771,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches tagB or tagC.
     let result = event_store.append(
@@ -782,7 +782,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches tagX or tagY.
     let result = event_store.append(
@@ -793,7 +793,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Fail because condition matches with type2 and tagB, or with type3 and tagC.
     let result = event_store.append(
@@ -804,7 +804,7 @@ pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
         }),
         None,
     );
-    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+    assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
     // Can append after 3.
     let position = event_store.append(new.clone(), None, None).unwrap();

--- a/tests-integration/tests/event_store_test.rs
+++ b/tests-integration/tests/event_store_test.rs
@@ -4,13 +4,13 @@ use tokio::runtime::Builder as RtBuilder;
 use umadb_client::UmaDBClient;
 use umadb_core::db::UmaDB;
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBEventStoreSync, DCBQuery, DCBQueryItem,
+    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem,
 };
 use umadb_server::start_server;
 use uuid::Uuid;
 
 // Helper function to run the test with implementations of the DCBEventStoreSync trait
-pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
+pub fn dcb_event_store_test<T: DcbEventStoreSync>(event_store: &T) {
     // Test head() method on empty store
     let head_position = event_store.head().unwrap();
     assert_eq!(None, head_position);
@@ -26,7 +26,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(None, head);
 
     // Append one event.
-    let event1 = DCBEvent {
+    let event1 = DcbEvent {
         event_type: "type1".to_string(),
         data: b"data1".to_vec(),
         tags: vec!["tagX".to_string()],
@@ -116,8 +116,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(None, head);
 
     // Read events with type1, expect 1 event.
-    let query_type1 = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_type1 = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec!["type1".to_string()],
             tags: vec![],
         }],
@@ -138,8 +138,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(1), head);
 
     // Read events with type2, expect no events.
-    let query_type2 = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_type2 = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec!["type2".to_string()],
             tags: vec![],
         }],
@@ -158,8 +158,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(1), head);
 
     // Read events with tagX, expect one event.
-    let query_tag_x = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_tag_x = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec![],
             tags: vec!["tagX".to_string()],
         }],
@@ -180,8 +180,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(1), head);
 
     // Read events with tagY, expect no events.
-    let query_tag_y = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_tag_y = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec![],
             tags: vec!["tagY".to_string()],
         }],
@@ -199,8 +199,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(1), head);
 
     // Read events with type1 and tagX, expect one event.
-    let query_type1_tag_x = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_type1_tag_x = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec!["type1".to_string()],
             tags: vec!["tagX".to_string()],
         }],
@@ -219,8 +219,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(1), head);
 
     // Read events with type1 and tagY, expect no events.
-    let query_type1_tag_y = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_type1_tag_y = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec!["type1".to_string()],
             tags: vec!["tagY".to_string()],
         }],
@@ -238,8 +238,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(1), head);
 
     // Read events with type2 and tagX, expect no events.
-    let query_type2_tag_x = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_type2_tag_x = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec!["type2".to_string()],
             tags: vec!["tagX".to_string()],
         }],
@@ -257,13 +257,13 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(1), head);
 
     // Append two more events.
-    let event2 = DCBEvent {
+    let event2 = DcbEvent {
         event_type: "type2".to_string(),
         data: b"data2".to_vec(),
         tags: vec!["tagA".to_string(), "tagB".to_string()],
         uuid: None,
     };
-    let event3 = DCBEvent {
+    let event3 = DcbEvent {
         event_type: "type3".to_string(),
         data: b"data3".to_vec(),
         tags: vec!["tagA".to_string(), "tagC".to_string()],
@@ -426,8 +426,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(3), head);
 
     // Read events with tagA, expect two events.
-    let query_tag_a = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_tag_a = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec![],
             tags: vec!["tagA".to_string()],
         }],
@@ -450,8 +450,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(3), head);
 
     // Read events with tagA and tagB, expect one event.
-    let query_tag_a_and_b = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_tag_a_and_b = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec![],
             tags: vec!["tagA".to_string(), "tagB".to_string()],
         }],
@@ -472,13 +472,13 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(3), head);
 
     // Read events with tagB or tagC, expect two events.
-    let query_tag_b_or_c = DCBQuery {
+    let query_tag_b_or_c = DcbQuery {
         items: vec![
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec![],
                 tags: vec!["tagB".to_string()],
             },
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec![],
                 tags: vec!["tagC".to_string()],
             },
@@ -502,13 +502,13 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(3), head);
 
     // Read events with tagX or tagY, expect one event.
-    let query_tag_x_or_y = DCBQuery {
+    let query_tag_x_or_y = DcbQuery {
         items: vec![
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec![],
                 tags: vec!["tagX".to_string()],
             },
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec![],
                 tags: vec!["tagY".to_string()],
             },
@@ -530,8 +530,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(3), head);
 
     // Read events with type2 and tagA, expect one event.
-    let query_type2_tag_a = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_type2_tag_a = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec!["type2".to_string()],
             tags: vec!["tagA".to_string()],
         }],
@@ -567,13 +567,13 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(3), head);
 
     // Read events with type2 and tagB, or with type3 and tagC, expect two events.
-    let query_type2_tag_b_or_type3_tagc = DCBQuery {
+    let query_type2_tag_b_or_type3_tagc = DcbQuery {
         items: vec![
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec!["type2".to_string()],
                 tags: vec!["tagB".to_string()],
             },
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec!["type3".to_string()],
                 tags: vec!["tagC".to_string()],
             },
@@ -620,13 +620,13 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(3), head);
 
     // Repeat with query items in different order, expect events in ascending order.
-    let query_type3_tag_c_or_type2_tag_b = DCBQuery {
+    let query_type3_tag_c_or_type2_tag_b = DcbQuery {
         items: vec![
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec!["type3".to_string()],
                 tags: vec!["tagC".to_string()],
             },
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec!["type2".to_string()],
                 tags: vec!["tagB".to_string()],
             },
@@ -673,7 +673,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(3), head);
 
     // Append must fail if recorded events match condition.
-    let event4 = DCBEvent {
+    let event4 = DcbEvent {
         event_type: "type4".to_string(),
         data: b"data4".to_vec(),
         tags: vec![],
@@ -682,137 +682,137 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
 
     // Fail because condition matches all.
     let new = vec![event4.clone()];
-    let result = event_store.append(new.clone(), Some(DCBAppendCondition::default()), None);
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    let result = event_store.append(new.clone(), Some(DcbAppendCondition::default()), None);
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches all after 1.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
-            fail_if_events_match: DCBQuery::default(),
+        Some(DcbAppendCondition {
+            fail_if_events_match: DcbQuery::default(),
             after: Some(1),
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches type1.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_type1.clone(),
             after: None,
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches type2 after 1.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_type2.clone(),
             after: Some(1),
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches tagX.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_tag_x.clone(),
             after: None,
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches tagA after 1.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_tag_a.clone(),
             after: Some(1),
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches type1 and tagX.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_type1_tag_x.clone(),
             after: None,
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches type2 and tagA after 1.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_type2_tag_a.clone(),
             after: Some(1),
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches tagA and tagB.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_tag_a_and_b.clone(),
             after: None,
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches tagB or tagC.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_tag_b_or_c.clone(),
             after: None,
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches tagX or tagY.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_tag_x_or_y.clone(),
             after: None,
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Fail because condition matches with type2 and tagB, or with type3 and tagC.
     let result = event_store.append(
         new.clone(),
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: query_type2_tag_b_or_type3_tagc.clone(),
             after: None,
         }),
         None,
     );
-    assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+    assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
     // Can append after 3.
     let position = event_store.append(new.clone(), None, None).unwrap();
     assert_eq!(4, position);
 
     // Can append match type_n.
-    let query_type_n = DCBQuery {
-        items: vec![DCBQueryItem {
+    let query_type_n = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec!["typeN".to_string()],
             tags: vec![],
         }],
@@ -820,7 +820,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let position = event_store
         .append(
             new.clone(),
-            Some(DCBAppendCondition {
+            Some(DcbAppendCondition {
                 fail_if_events_match: query_type_n,
                 after: None,
             }),
@@ -833,7 +833,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let position = event_store
         .append(
             new.clone(),
-            Some(DCBAppendCondition {
+            Some(DcbAppendCondition {
                 fail_if_events_match: query_tag_y.clone(),
                 after: None,
             }),
@@ -846,7 +846,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let position = event_store
         .append(
             new.clone(),
-            Some(DCBAppendCondition {
+            Some(DcbAppendCondition {
                 fail_if_events_match: query_type1.clone(),
                 after: Some(1),
             }),
@@ -859,7 +859,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let position = event_store
         .append(
             new.clone(),
-            Some(DCBAppendCondition {
+            Some(DcbAppendCondition {
                 fail_if_events_match: query_tag_x.clone(),
                 after: Some(1),
             }),
@@ -872,7 +872,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let position = event_store
         .append(
             new.clone(),
-            Some(DCBAppendCondition {
+            Some(DcbAppendCondition {
                 fail_if_events_match: query_type1_tag_x.clone(),
                 after: Some(1),
             }),
@@ -885,7 +885,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let position = event_store
         .append(
             new.clone(),
-            Some(DCBAppendCondition {
+            Some(DcbAppendCondition {
                 fail_if_events_match: query_tag_x.clone(),
                 after: Some(1),
             }),
@@ -896,7 +896,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
 
     // Check it works with course subscription consistency boundaries and events.
     let student_id = format!("student1-{}", Uuid::new_v4());
-    let student_registered = DCBEvent {
+    let student_registered = DcbEvent {
         event_type: "StudentRegistered".to_string(),
         data: format!(r#"{{"name": "Student1", "max_courses": 10}}"#).into_bytes(),
         tags: vec![student_id.clone()],
@@ -904,14 +904,14 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     };
 
     let course_id = format!("course1-{}", Uuid::new_v4());
-    let course_registered = DCBEvent {
+    let course_registered = DcbEvent {
         event_type: "CourseRegistered".to_string(),
         data: format!(r#"{{"name": "Course1", "places": 10}}"#).into_bytes(),
         tags: vec![course_id.clone()],
         uuid: None,
     };
 
-    let student_joined_course = DCBEvent {
+    let student_joined_course = DcbEvent {
         event_type: "StudentJoinedCourse".to_string(),
         data: format!(
             r#"{{"student_id": "{}", "course_id": "{}"}}"#,
@@ -925,9 +925,9 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let _position = event_store
         .append(
             vec![student_registered.clone()],
-            Some(DCBAppendCondition {
-                fail_if_events_match: DCBQuery {
-                    items: vec![DCBQueryItem {
+            Some(DcbAppendCondition {
+                fail_if_events_match: DcbQuery {
+                    items: vec![DcbQueryItem {
                         types: vec!["StudentRegistered".to_string()],
                         tags: student_registered.tags.clone(),
                     }],
@@ -941,9 +941,9 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let _position = event_store
         .append(
             vec![course_registered.clone()],
-            Some(DCBAppendCondition {
-                fail_if_events_match: DCBQuery {
-                    items: vec![DCBQueryItem {
+            Some(DcbAppendCondition {
+                fail_if_events_match: DcbQuery {
+                    items: vec![DcbQueryItem {
                         types: vec![],
                         tags: course_registered.tags.clone(),
                     }],
@@ -957,9 +957,9 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let _position = event_store
         .append(
             vec![student_joined_course.clone()],
-            Some(DCBAppendCondition {
-                fail_if_events_match: DCBQuery {
-                    items: vec![DCBQueryItem {
+            Some(DcbAppendCondition {
+                fail_if_events_match: DcbQuery {
+                    items: vec![DcbQueryItem {
                         types: vec![],
                         tags: student_joined_course.tags.clone(),
                     }],
@@ -1004,8 +1004,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read student
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![student_id.clone()],
                 }],
@@ -1023,8 +1023,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read student backwards
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![student_id.clone()],
                 }],
@@ -1042,8 +1042,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read course
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![course_id.clone()],
                 }],
@@ -1061,8 +1061,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read course backwards
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![course_id.clone()],
                 }],
@@ -1079,8 +1079,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
 
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![
                         student_joined_course.tags[0].clone(),
@@ -1099,8 +1099,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read student start position 3
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![student_id.clone()],
                 }],
@@ -1116,8 +1116,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read student backwards start position 3
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![student_id.clone()],
                 }],
@@ -1133,8 +1133,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read course start position 3
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![course_id.clone()],
                 }],
@@ -1150,8 +1150,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read course backwards start position 3
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![course_id.clone()],
                 }],
@@ -1167,8 +1167,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read joined course start position 3
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![
                         student_joined_course.tags[0].clone(),
@@ -1187,8 +1187,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read joined course backwards start position 3
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![
                         student_joined_course.tags[0].clone(),
@@ -1207,8 +1207,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read student start position 3 limit 1
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![student_id.clone()],
                 }],
@@ -1224,8 +1224,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read student backwards start position 13 limit 1
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![student_id.clone()],
                 }],
@@ -1241,8 +1241,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read course start position 3 limit 1
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![course_id.clone()],
                 }],
@@ -1258,8 +1258,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read course backwards start position 13 limit 1
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![course_id.clone()],
                 }],
@@ -1275,8 +1275,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read joined course start position 3 limit 1
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![
                         student_joined_course.tags[0].clone(),
@@ -1295,8 +1295,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     // Read joined course backwards start position 13 limit 1
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![
                         student_joined_course.tags[0].clone(),
@@ -1313,16 +1313,16 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(13), head);
 
     // Read both students
-    let consistency_boundary = DCBQuery {
+    let consistency_boundary = DcbQuery {
         items: vec![
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec![
                     "StudentRegistered".to_string(),
                     "StudentJoinedCourse".to_string(),
                 ],
                 tags: vec![student_id.clone()],
             },
-            DCBQueryItem {
+            DcbQueryItem {
                 types: vec![
                     "CourseRegistered".to_string(),
                     "StudentJoinedCourse".to_string(),
@@ -1355,7 +1355,7 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     assert_eq!(Some(13), head_position);
 
     // Test UUID attribute is maintained.
-    let event5 = DCBEvent {
+    let event5 = DcbEvent {
         event_type: "type5".to_string(),
         data: b"data5".to_vec(),
         tags: vec!["tag5".to_string()],
@@ -1365,9 +1365,9 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let commit_position5 = event_store
         .append(
             vec![event5.clone()],
-            Some(DCBAppendCondition {
-                fail_if_events_match: DCBQuery {
-                    items: vec![DCBQueryItem {
+            Some(DcbAppendCondition {
+                fail_if_events_match: DcbQuery {
+                    items: vec![DcbQueryItem {
                         types: vec![],
                         tags: event5.tags.clone(),
                     }],
@@ -1380,8 +1380,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
 
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: event5.tags.clone(),
                 }],
@@ -1400,9 +1400,9 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
     let commit_position6 = event_store
         .append(
             vec![event5.clone()],
-            Some(DCBAppendCondition {
-                fail_if_events_match: DCBQuery {
-                    items: vec![DCBQueryItem {
+            Some(DcbAppendCondition {
+                fail_if_events_match: DcbQuery {
+                    items: vec![DcbQueryItem {
                         types: vec![],
                         tags: event5.tags.clone(),
                     }],
@@ -1417,8 +1417,8 @@ pub fn dcb_event_store_test<T: DCBEventStoreSync>(event_store: &T) {
 
     let (result, head) = event_store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: event5.tags.clone(),
                 }],
@@ -1501,13 +1501,13 @@ fn test_tag_hash_collision() {
     let store = UmaDB::new(temp_dir.path()).unwrap();
 
     // Append two events, one per colliding tag
-    let ev_student = DCBEvent {
+    let ev_student = DcbEvent {
         event_type: "StudentEvent".to_string(),
         data: b"student-data".to_vec(),
         tags: vec![student_tag.clone()],
         uuid: None,
     };
-    let ev_course = DCBEvent {
+    let ev_course = DcbEvent {
         event_type: "CourseEvent".to_string(),
         data: b"course-data".to_vec(),
         tags: vec![course_tag.clone()],
@@ -1520,8 +1520,8 @@ fn test_tag_hash_collision() {
     // Query by student tag: should return only the student event
     let (result, _head) = store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![student_tag.clone()],
                 }],
@@ -1542,8 +1542,8 @@ fn test_tag_hash_collision() {
     // Query by course tag: should return only the course event
     let (result, _head) = store
         .read_with_head(
-            Some(DCBQuery {
-                items: vec![DCBQueryItem {
+            Some(DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec![course_tag.clone()],
                 }],
@@ -1564,13 +1564,13 @@ fn test_tag_hash_collision() {
     // Query with two items (student tag OR course tag): should return both events
     let (result, _head) = store
         .read_with_head(
-            Some(DCBQuery {
+            Some(DcbQuery {
                 items: vec![
-                    DCBQueryItem {
+                    DcbQueryItem {
                         types: vec![],
                         tags: vec![student_tag.clone()],
                     },
-                    DCBQueryItem {
+                    DcbQueryItem {
                         types: vec![],
                         tags: vec![course_tag.clone()],
                     },

--- a/tests-integration/tests/grpc_streaming_test.rs
+++ b/tests-integration/tests/grpc_streaming_test.rs
@@ -1,5 +1,5 @@
 use umadb_client::UmaDBClient;
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync};
 use umadb_server::start_server;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -23,8 +23,8 @@ async fn grpc_async_streams_large_reads_total_count() {
         .expect("client connect");
 
     // Append 1000 events
-    let events: Vec<DCBEvent> = (0..1000)
-        .map(|i| DCBEvent {
+    let events: Vec<DcbEvent> = (0..1000)
+        .map(|i| DcbEvent {
             event_type: "TestEvent".to_string(),
             data: format!("data-{i}").into_bytes(),
             tags: vec!["grpc-test".to_string()],
@@ -78,8 +78,8 @@ async fn grpc_async_does_not_stream_past_starting_head() {
         .expect("client connect");
 
     // Append initial 300 events
-    let initial_events: Vec<DCBEvent> = (0..300)
-        .map(|i| DCBEvent {
+    let initial_events: Vec<DcbEvent> = (0..300)
+        .map(|i| DcbEvent {
             event_type: "TestEvent".to_string(),
             data: format!("data-{i}").into_bytes(),
             tags: vec!["grpc-boundary".to_string()],
@@ -98,8 +98,8 @@ async fn grpc_async_does_not_stream_past_starting_head() {
         .expect("read_stream");
 
     // Append 50 more events AFTER the read has started
-    let new_events: Vec<DCBEvent> = (0..50)
-        .map(|i| DCBEvent {
+    let new_events: Vec<DcbEvent> = (0..50)
+        .map(|i| DcbEvent {
             event_type: "TestEvent2".to_string(),
             data: format!("new-{i}").into_bytes(),
             tags: vec!["grpc-boundary".to_string()],
@@ -148,8 +148,8 @@ async fn grpc_async_subscription_catch_up_and_continue() {
 
     // Append initial events
     let initial_count = 40usize;
-    let initial_events: Vec<DCBEvent> = (0..initial_count as u64)
-        .map(|i| DCBEvent {
+    let initial_events: Vec<DcbEvent> = (0..initial_count as u64)
+        .map(|i| DcbEvent {
             event_type: "SubTestEvent".to_string(),
             data: format!("init-{i}").into_bytes(),
             tags: vec!["grpc-sub".to_string()],
@@ -188,8 +188,8 @@ async fn grpc_async_subscription_catch_up_and_continue() {
 
     // Append more events and ensure they also arrive
     let new_count = 25usize;
-    let new_events: Vec<DCBEvent> = (0..new_count as u64)
-        .map(|i| DCBEvent {
+    let new_events: Vec<DcbEvent> = (0..new_count as u64)
+        .map(|i| DcbEvent {
             event_type: "SubTestEvent2".to_string(),
             data: format!("new-{i}").into_bytes(),
             tags: vec!["grpc-sub".to_string()],
@@ -244,8 +244,8 @@ async fn grpc_async_stream_catch_up_and_continue() {
 
     // Append initial events via async API
     let initial_count = 15usize;
-    let initial_events: Vec<DCBEvent> = (0..initial_count as u64)
-        .map(|i| DCBEvent {
+    let initial_events: Vec<DcbEvent> = (0..initial_count as u64)
+        .map(|i| DcbEvent {
             event_type: "AsyncEvent".to_string(),
             data: format!("init-{i}").into_bytes(),
             tags: vec!["grpc-async".to_string()],
@@ -279,8 +279,8 @@ async fn grpc_async_stream_catch_up_and_continue() {
 
     // Append more events via async API
     let new_count = 7usize;
-    let new_events: Vec<DCBEvent> = (0..new_count as u64)
-        .map(|i| DCBEvent {
+    let new_events: Vec<DcbEvent> = (0..new_count as u64)
+        .map(|i| DcbEvent {
             event_type: "AsyncEvent2".to_string(),
             data: format!("new-{i}").into_bytes(),
             tags: vec!["grpc-async".to_string()],

--- a/tests-integration/tests/grpc_subscribe_methods_test.rs
+++ b/tests-integration/tests/grpc_subscribe_methods_test.rs
@@ -2,7 +2,7 @@ use std::net::TcpListener;
 use tempfile::tempdir;
 use tokio::time::{Duration as TokioDuration, sleep};
 use umadb_client::UmaDBClient;
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync, DCBEventStoreSync};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync, DcbEventStoreSync};
 use umadb_server::start_server;
 
 // ----------------------
@@ -32,8 +32,8 @@ async fn grpc_async_subscribe_catch_up_and_continue() {
 
     // Append initial events
     let initial_count = 30usize;
-    let initial_events: Vec<DCBEvent> = (0..initial_count as u64)
-        .map(|i| DCBEvent {
+    let initial_events: Vec<DcbEvent> = (0..initial_count as u64)
+        .map(|i| DcbEvent {
             event_type: "AsyncSubEvent".to_string(),
             data: format!("init-{i}").into_bytes(),
             tags: vec!["grpc-async-sub".to_string()],
@@ -68,8 +68,8 @@ async fn grpc_async_subscribe_catch_up_and_continue() {
 
     // Append more events and ensure they arrive on the same subscription
     let new_count = 12usize;
-    let new_events: Vec<DCBEvent> = (0..new_count as u64)
-        .map(|i| DCBEvent {
+    let new_events: Vec<DcbEvent> = (0..new_count as u64)
+        .map(|i| DcbEvent {
             event_type: "AsyncSubEvent2".to_string(),
             data: format!("new-{i}").into_bytes(),
             tags: vec!["grpc-async-sub".to_string()],
@@ -122,8 +122,8 @@ async fn grpc_async_subscribe_with_after_position() {
 
     // Append A initial events
     let a = 20usize;
-    let initial_events: Vec<DCBEvent> = (0..a as u64)
-        .map(|i| DCBEvent {
+    let initial_events: Vec<DcbEvent> = (0..a as u64)
+        .map(|i| DcbEvent {
             event_type: "AsyncSubStartEvent".to_string(),
             data: format!("init-{i}").into_bytes(),
             tags: vec!["grpc-async-sub-start".to_string()],
@@ -163,8 +163,8 @@ async fn grpc_async_subscribe_with_after_position() {
 
     // Append M new events and ensure they arrive
     let m = 9usize;
-    let new_events: Vec<DCBEvent> = (0..m as u64)
-        .map(|i| DCBEvent {
+    let new_events: Vec<DcbEvent> = (0..m as u64)
+        .map(|i| DcbEvent {
             event_type: "AsyncSubStartEvent2".to_string(),
             data: format!("new-{i}").into_bytes(),
             tags: vec!["grpc-async-sub-start".to_string()],
@@ -250,8 +250,8 @@ fn grpc_sync_subscribe_catch_up_and_continue() {
 
     // Append initial events via sync API
     let initial_count = 20usize;
-    let initial_events: Vec<DCBEvent> = (0..initial_count as u64)
-        .map(|i| DCBEvent {
+    let initial_events: Vec<DcbEvent> = (0..initial_count as u64)
+        .map(|i| DcbEvent {
             event_type: "SyncSubEvent".to_string(),
             data: format!("init-{i}").into_bytes(),
             tags: vec!["grpc-sync-sub".to_string()],
@@ -274,8 +274,8 @@ fn grpc_sync_subscribe_catch_up_and_continue() {
 
     // Append more and ensure they arrive
     let new_count = 11usize;
-    let new_events: Vec<DCBEvent> = (0..new_count as u64)
-        .map(|i| DCBEvent {
+    let new_events: Vec<DcbEvent> = (0..new_count as u64)
+        .map(|i| DcbEvent {
             event_type: "SyncSubEvent2".to_string(),
             data: format!("new-{i}").into_bytes(),
             tags: vec!["grpc-sync-sub".to_string()],

--- a/tests-integration/tests/next_batch_behaviour.rs
+++ b/tests-integration/tests/next_batch_behaviour.rs
@@ -9,7 +9,7 @@ use tonic_health::pb::health_check_response::ServingStatus as PbServingStatus;
 use tonic_health::pb::health_client::HealthClient;
 
 use umadb_client::UmaDBClient;
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync};
 use umadb_server::start_server;
 use uuid::Uuid;
 
@@ -101,7 +101,7 @@ async fn next_batch_returns_all_then_empty_when_unlimited_and_large_batch_size()
 
     // Append 3 events
     let mk_event = |i: u8| {
-        DCBEvent::default()
+        DcbEvent::default()
             .event_type("ExampleEvent")
             .tags(["tagA", "tagB"]) // any tags
             .data(vec![i])

--- a/tests-integration/tests/path_rewrite_test.rs
+++ b/tests-integration/tests/path_rewrite_test.rs
@@ -3,7 +3,7 @@ use std::net::TcpListener;
 use tempfile::tempdir;
 use tokio::runtime::Builder as RtBuilder;
 use umadb_client::UmaDBClient;
-use umadb_dcb::DCBEvent;
+use umadb_dcb::DcbEvent;
 use umadb_proto::v1::HeadRequest;
 use umadb_server::start_server;
 
@@ -71,21 +71,21 @@ fn test_path_rewrite_umadbservice_to_dcb() {
     };
 
     // Append some events using the normal client
-    use umadb_dcb::DCBEventStoreSync;
+    use umadb_dcb::DcbEventStoreSync;
     let events = vec![
-        DCBEvent {
+        DcbEvent {
             event_type: "TestEvent".to_string(),
             data: b"test data 1".to_vec(),
             tags: vec!["tag1".to_string()],
             uuid: None,
         },
-        DCBEvent {
+        DcbEvent {
             event_type: "TestEvent".to_string(),
             data: b"test data 2".to_vec(),
             tags: vec!["tag2".to_string()],
             uuid: None,
         },
-        DCBEvent {
+        DcbEvent {
             event_type: "TestEvent".to_string(),
             data: b"test data 3".to_vec(),
             tags: vec!["tag3".to_string()],

--- a/tests-integration/tests/schema_version_0_compat_test.rs
+++ b/tests-integration/tests/schema_version_0_compat_test.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use tempfile::tempdir;
 use umadb_core::db::UmaDB;
 use umadb_core::tags_tree_nodes::get_tag_key_width;
-use umadb_dcb::{DCBEvent, DCBEventStoreSync, DCBQuery, DCBQueryItem};
+use umadb_dcb::{DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem};
 
 // This test verifies that a legacy schema version 0 (with 64-bit tag hashes)
 // can be opened, queried, and appended to by the current code.
@@ -64,7 +64,7 @@ fn schema_version_0_roundtrip_read_write_and_tags() -> Result<(), Box<dyn std::e
         // For each tag, query events filtered by that tag and ensure we get >=1 result
         // First: pure index path (all items have tags) to validate index-based search on legacy DB
         for tag in &existing_tags {
-            let query = DCBQuery::new().item(DCBQueryItem::new().tags([tag.clone()]));
+            let query = DcbQuery::new().item(DcbQueryItem::new().tags([tag.clone()]));
             let (tag_events, _head2) = db.read_with_head(Some(query), None, false, None)?;
             assert!(
                 !tag_events.is_empty(),
@@ -75,9 +75,9 @@ fn schema_version_0_roundtrip_read_write_and_tags() -> Result<(), Box<dyn std::e
 
         // Second: force sequential fallback path while still filtering by the tag, should also work
         let build_tag_query_fallback = |t: &str| {
-            DCBQuery::new()
-                .item(DCBQueryItem::new().tags([t]))
-                .item(DCBQueryItem::new().types(["__no_such_type__"]))
+            DcbQuery::new()
+                .item(DcbQueryItem::new().tags([t]))
+                .item(DcbQueryItem::new().types(["__no_such_type__"]))
         };
 
         for tag in &existing_tags {
@@ -93,7 +93,7 @@ fn schema_version_0_roundtrip_read_write_and_tags() -> Result<(), Box<dyn std::e
         // Append a few new events with brand-new tags
         let new_tags = vec!["compat-new-A", "compat-new-B", "compat-new-C"];
         for (i, nt) in new_tags.iter().enumerate() {
-            let ev = DCBEvent {
+            let ev = DcbEvent {
                 event_type: format!("CompatEvent{}", i + 1),
                 data: format!("payload-{}", i + 1).into_bytes(),
                 tags: vec![nt.to_string()],
@@ -109,7 +109,7 @@ fn schema_version_0_roundtrip_read_write_and_tags() -> Result<(), Box<dyn std::e
 
         // Verify per-tag queries for the new tags return exactly one event
         for (i, nt) in new_tags.iter().enumerate() {
-            let query = DCBQuery::new().item(DCBQueryItem::new().tags([*nt]));
+            let query = DcbQuery::new().item(DcbQueryItem::new().tags([*nt]));
             let (events_for_tag, _h) = db.read_with_head(Some(query), None, false, None)?;
             assert_eq!(
                 1,

--- a/tests-integration/tests/secure_grpc.rs
+++ b/tests-integration/tests/secure_grpc.rs
@@ -5,7 +5,7 @@ use rcgen::generate_simple_self_signed;
 use tempfile::tempdir;
 use tokio::time::sleep;
 use umadb_client::{AsyncUmaDBClient, ClientTlsOptions};
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync};
 use umadb_server::start_server_secure;
 
 // Helper to pick a free localhost port
@@ -90,8 +90,8 @@ async fn secure_grpc_end_to_end_append_and_read() {
     };
 
     // Append a handful of events
-    let events: Vec<DCBEvent> = (0..25)
-        .map(|i| DCBEvent {
+    let events: Vec<DcbEvent> = (0..25)
+        .map(|i| DcbEvent {
             event_type: "SecureTest".to_string(),
             data: format!("tls-data-{}", i).into_bytes(),
             tags: vec!["secure".to_string()],

--- a/tests-integration/tests/tracking_grpc.rs
+++ b/tests-integration/tests/tracking_grpc.rs
@@ -1,5 +1,5 @@
 use umadb_client::UmaDBClient;
-use umadb_dcb::{DdbError, DcbEvent, DcbEventStoreAsync, TrackingInfo};
+use umadb_dcb::{DcbError, DcbEvent, DcbEventStoreAsync, TrackingInfo};
 use umadb_server::start_server;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -66,7 +66,7 @@ async fn grpc_append_with_tracking_enforces_monotonicity() {
         .err()
         .expect("expected integrity error on non-increasing tracking");
     match err {
-        DdbError::IntegrityError(msg) => {
+        DcbError::IntegrityError(msg) => {
             assert!(msg.contains("non-increasing tracking position"))
         }
         other => panic!("unexpected error: {:?}", other),

--- a/tests-integration/tests/tracking_grpc.rs
+++ b/tests-integration/tests/tracking_grpc.rs
@@ -1,5 +1,5 @@
 use umadb_client::UmaDBClient;
-use umadb_dcb::{DCBError, DCBEvent, DCBEventStoreAsync, TrackingInfo};
+use umadb_dcb::{DdbError, DcbEvent, DcbEventStoreAsync, TrackingInfo};
 use umadb_server::start_server;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -25,7 +25,7 @@ async fn grpc_append_with_tracking_enforces_monotonicity() {
         .expect("client connect");
 
     // Build a simple event
-    let ev = DCBEvent {
+    let ev = DcbEvent {
         event_type: "TrackEvt".to_string(),
         data: b"d".to_vec(),
         tags: vec!["t".to_string()],
@@ -66,7 +66,7 @@ async fn grpc_append_with_tracking_enforces_monotonicity() {
         .err()
         .expect("expected integrity error on non-increasing tracking");
     match err {
-        DCBError::IntegrityError(msg) => {
+        DdbError::IntegrityError(msg) => {
             assert!(msg.contains("non-increasing tracking position"))
         }
         other => panic!("unexpected error: {:?}", other),

--- a/tests-integration/tests/unconditional_append_hotspot.rs
+++ b/tests-integration/tests/unconditional_append_hotspot.rs
@@ -3,7 +3,7 @@ use std::hint::black_box;
 use std::time::Instant;
 use tempfile::tempdir;
 use umadb_core::db::UmaDB;
-use umadb_dcb::{DCBAppendCondition, DCBEvent, DCBEventStoreSync, DCBQuery, DCBQueryItem};
+use umadb_dcb::{DcbAppendCondition, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem};
 
 // This test is intended for profiling hotspots when appending events.
 // It can append one event per call or many events per call, to profile both per-call overhead
@@ -62,7 +62,7 @@ fn profile_event_store_append() {
 
     let payload = vec![0u8; data_size];
     for i in 0..calls_per_run {
-        let mut events: Vec<DCBEvent> = Vec::with_capacity(events_per_call);
+        let mut events: Vec<DcbEvent> = Vec::with_capacity(events_per_call);
         for j in 0..events_per_call {
             let idx = i + j;
 
@@ -72,7 +72,7 @@ fn profile_event_store_append() {
                 tags.push(format!("tag-{j}-{k}"));
             }
 
-            let event = DCBEvent {
+            let event = DcbEvent {
                 event_type: format!("Type{}", idx % 16),
                 data: payload.clone(),
                 tags,
@@ -80,9 +80,9 @@ fn profile_event_store_append() {
             };
             events.push(event);
         }
-        let condition = DCBAppendCondition {
-            fail_if_events_match: DCBQuery {
-                items: vec![DCBQueryItem {
+        let condition = DcbAppendCondition {
+            fail_if_events_match: DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec!["foo".to_string()],
                 }],

--- a/umadb-benches/benches/grpc_append_bench.rs
+++ b/umadb-benches/benches/grpc_append_bench.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Builder as RtBuilder;
 use tokio::sync::oneshot;
 use umadb_client::{AsyncUmaDBClient, UmaDBClient};
 use umadb_core::db::UmaDB;
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync, DCBEventStoreSync};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync, DcbEventStoreSync};
 use umadb_server::start_server;
 
 fn get_events_per_request() -> usize {
@@ -40,7 +40,7 @@ fn init_db_with_events(num_events: usize) -> (tempfile::TempDir, String) {
         let current = remaining.min(batch_size);
         let mut events = Vec::with_capacity(current);
         for i in 0..current {
-            let ev = DCBEvent {
+            let ev = DcbEvent {
                 event_type: "bench-init".to_string(),
                 data: format!("init-{}", i).into_bytes(),
                 tags: vec!["init".to_string()],
@@ -146,8 +146,8 @@ pub fn grpc_append_benchmark(c: &mut Criterion) {
             let clients = clients.clone();
             b.iter(|| {
                 // Build the batch of events per iteration (per task)
-                let events: Vec<DCBEvent> = (0..events_per_request)
-                    .map(|i| DCBEvent {
+                let events: Vec<DcbEvent> = (0..events_per_request)
+                    .map(|i| DcbEvent {
                         event_type: "bench-append".to_string(),
                         data: format!("data-{i}").into_bytes(),
                         tags: vec!["append".to_string()],

--- a/umadb-benches/benches/grpc_append_cond_bench.rs
+++ b/umadb-benches/benches/grpc_append_cond_bench.rs
@@ -11,7 +11,7 @@ use tokio::sync::oneshot;
 use umadb_client::{AsyncUmaDBClient, UmaDBClient};
 use umadb_core::db::UmaDB;
 use umadb_dcb::{
-    DCBAppendCondition, DCBEvent, DCBEventStoreAsync, DCBEventStoreSync, DCBQuery, DCBQueryItem,
+    DcbAppendCondition, DcbEvent, DcbEventStoreAsync, DcbEventStoreSync, DcbQuery, DcbQueryItem,
 };
 use umadb_server::start_server;
 
@@ -43,7 +43,7 @@ fn init_db_with_events(num_events: usize) -> (tempfile::TempDir, String, u64) {
         let current = remaining.min(batch_size);
         let mut events = Vec::with_capacity(current);
         for i in 0..current {
-            let ev = DCBEvent {
+            let ev = DcbEvent {
                 event_type: "bench-init".to_string(),
                 data: format!("init-{}", i).into_bytes(),
                 tags: vec!["init".to_string()],
@@ -149,8 +149,8 @@ pub fn grpc_append_cond_benchmark(c: &mut Criterion) {
             let clients = clients.clone();
             b.iter(|| {
                 // Build the batch of events per iteration (per task)
-                let events: Vec<DCBEvent> = (0..events_per_request)
-                    .map(|i| DCBEvent {
+                let events: Vec<DcbEvent> = (0..events_per_request)
+                    .map(|i| DcbEvent {
                         event_type: "bench-append".to_string(),
                         data: format!("data-{i}").into_bytes(),
                         tags: vec!["append".to_string()],
@@ -166,9 +166,9 @@ pub fn grpc_append_cond_benchmark(c: &mut Criterion) {
                         let evs = events.clone();
                         async move {
                             // Build append condition: fail if any "init" tagged events exist after last_init_pos
-                            let condition = DCBAppendCondition {
-                                fail_if_events_match: DCBQuery {
-                                    items: vec![DCBQueryItem {
+                            let condition = DcbAppendCondition {
+                                fail_if_events_match: DcbQuery {
+                                    items: vec![DcbQueryItem {
                                         types: vec![],
                                         tags: vec!["init".to_string()],
                                     }],

--- a/umadb-benches/benches/grpc_append_with_readers_bench.rs
+++ b/umadb-benches/benches/grpc_append_with_readers_bench.rs
@@ -13,7 +13,7 @@ use tokio::runtime::Builder as RtBuilder;
 use tokio::sync::oneshot;
 use umadb_client::{AsyncUmaDBClient, UmaDBClient};
 use umadb_core::db::UmaDB;
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync, DCBEventStoreSync};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync, DcbEventStoreSync};
 use umadb_server::start_server;
 
 fn init_db_with_events(num_events: usize) -> (tempfile::TempDir, String) {
@@ -30,7 +30,7 @@ fn init_db_with_events(num_events: usize) -> (tempfile::TempDir, String) {
         let current = remaining.min(batch_size);
         let mut events = Vec::with_capacity(current);
         for i in 0..current {
-            let ev = DCBEvent {
+            let ev = DcbEvent {
                 event_type: "bench-init".to_string(),
                 data: format!("init-{}", i).into_bytes(),
                 tags: vec!["init".to_string()],
@@ -180,8 +180,8 @@ pub fn grpc_append_with_readers_benchmark(c: &mut Criterion) {
             let clients = clients.clone();
             b.iter(|| {
                 // Build the batch of events per iteration (per task)
-                let events: Vec<DCBEvent> = (0..events_per_iter)
-                    .map(|i| DCBEvent {
+                let events: Vec<DcbEvent> = (0..events_per_iter)
+                    .map(|i| DcbEvent {
                         event_type: "bench-append".to_string(),
                         data: format!("data-{}", i).into_bytes(),
                         tags: vec!["append".to_string()],

--- a/umadb-benches/benches/grpc_read_bench.rs
+++ b/umadb-benches/benches/grpc_read_bench.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Builder as RtBuilder;
 use tokio::sync::oneshot;
 use umadb_client::{AsyncUmaDBClient, UmaDBClient};
 use umadb_core::db::UmaDB;
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync, DCBEventStoreSync};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync, DcbEventStoreSync};
 use umadb_server::start_server;
 
 fn get_max_threads() -> Option<usize> {
@@ -40,7 +40,7 @@ fn init_db_with_events(num_events: usize) -> (tempfile::TempDir, String) {
         let current = remaining.min(batch_size);
         let mut events = Vec::with_capacity(current);
         for i in 0..current {
-            let ev = DCBEvent {
+            let ev = DcbEvent {
                 event_type: "bench".to_string(),
                 data: format!("event-{}", i).into_bytes(),
                 tags: vec!["tag1".to_string()],

--- a/umadb-benches/benches/grpc_read_cond_bench.rs
+++ b/umadb-benches/benches/grpc_read_cond_bench.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Builder as RtBuilder;
 use tokio::sync::oneshot;
 use umadb_client::{AsyncUmaDBClient, UmaDBClient};
 use umadb_core::db::UmaDB;
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync, DCBEventStoreSync, DCBQuery, DCBQueryItem};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync, DcbEventStoreSync, DcbQuery, DcbQueryItem};
 use umadb_server::start_server;
 
 const EVENTS_PER_TAG: u32 = 10;
@@ -33,7 +33,7 @@ fn init_db_with_events() -> (tempfile::TempDir, String) {
     for _ in 0..EVENTS_PER_TAG {
         let mut events = Vec::with_capacity(NUM_TAGS as usize);
         for j in 0..NUM_TAGS {
-            let ev = DCBEvent {
+            let ev = DcbEvent {
                 event_type: "bench".to_string(),
                 data: format!("event-{}", j).into_bytes(),
                 tags: vec![format!("tag-{}", j).to_string()],
@@ -48,7 +48,7 @@ fn init_db_with_events() -> (tempfile::TempDir, String) {
 }
 
 pub fn grpc_read_cond_benchmark(c: &mut Criterion) {
-    let query = DCBQuery::new().item(DCBQueryItem::new().tags(["tag-500"]));
+    let query = DcbQuery::new().item(DcbQueryItem::new().tags(["tag-500"]));
 
     // Initialize DB and server with some events
     let (_tmp_dir, db_path) = init_db_with_events();

--- a/umadb-benches/benches/grpc_read_flame.rs
+++ b/umadb-benches/benches/grpc_read_flame.rs
@@ -14,7 +14,7 @@ fn main() -> std::io::Result<()> {
     use tokio::sync::oneshot;
     use umadb_client::AsyncUmaDBClient;
     use umadb_core::db::UmaDB;
-    use umadb_dcb::{DCBEvent, DCBEventStoreAsync, DCBEventStoreSync};
+    use umadb_dcb::{DcbEvent, DcbEventStoreAsync, DcbEventStoreSync};
     use umadb_server::start_server;
 
     fn init_db_with_events(num_events: usize) -> (tempfile::TempDir, String) {
@@ -31,7 +31,7 @@ fn main() -> std::io::Result<()> {
             let current = remaining.min(batch_size);
             let mut events = Vec::with_capacity(current);
             for i in 0..current {
-                let ev = DCBEvent {
+                let ev = DcbEvent {
                     event_type: "bench".to_string(),
                     data: format!("event-{}", i).into_bytes(),
                     tags: vec!["tag1".to_string()],

--- a/umadb-benches/benches/grpc_read_with_writers_bench.rs
+++ b/umadb-benches/benches/grpc_read_with_writers_bench.rs
@@ -13,7 +13,7 @@ use tokio::runtime::Builder as RtBuilder;
 use tokio::sync::oneshot;
 use umadb_client::{AsyncUmaDBClient, UmaDBClient};
 use umadb_core::db::UmaDB;
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync, DCBEventStoreSync};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync, DcbEventStoreSync};
 use umadb_server::start_server;
 
 fn get_max_threads() -> Option<usize> {
@@ -36,7 +36,7 @@ fn init_db_with_events(num_events: usize) -> (tempfile::TempDir, String) {
         let current = remaining.min(batch_size);
         let mut events = Vec::with_capacity(current);
         for i in 0..current {
-            let ev = DCBEvent {
+            let ev = DcbEvent {
                 event_type: "bench".to_string(),
                 data: format!("event-{}", i).into_bytes(),
                 tags: vec!["tag1".to_string()],
@@ -122,8 +122,8 @@ pub fn grpc_read_with_writers_benchmark(c: &mut Criterion) {
     }
 
     // Prebuild a tiny event batch for each append
-    let writer_batch: Vec<DCBEvent> = (0..WRITER_EVENTS_PER_APPEND)
-        .map(|i| DCBEvent {
+    let writer_batch: Vec<DcbEvent> = (0..WRITER_EVENTS_PER_APPEND)
+        .map(|i| DcbEvent {
             event_type: "writer".to_string(),
             data: format!("w-{}", i).into_bytes(),
             tags: vec!["w".to_string()],

--- a/umadb-benches/benches/mvcc_commit_flame_at_large_volume.rs
+++ b/umadb-benches/benches/mvcc_commit_flame_at_large_volume.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use std::path::Path;
 use umadb_core::db::unconditional_append;
-use umadb_dcb::DCBEvent;
+use umadb_dcb::DcbEvent;
 use uuid::Uuid;
 
 fn main() -> std::io::Result<()> {
@@ -60,7 +60,7 @@ fn main() -> std::io::Result<()> {
             let start = Instant::now();
             for _ in 0..1000 {
                 let mut w = db.writer();
-                let event = DCBEvent {
+                let event = DcbEvent {
                     event_type: "batch-type".to_string(),
                     data: "batch-data".to_string().into_bytes(),
                     tags: vec![format!("tag-{}", Uuid::new_v4())],
@@ -85,7 +85,7 @@ fn main() -> std::io::Result<()> {
 
             for _ in 0..1000 {
                 let mut w = db.writer();
-                let event = DCBEvent {
+                let event = DcbEvent {
                     event_type: "batch-type".to_string(),
                     data: "batch-data".to_string().into_bytes(),
                     tags: vec![format!("tag-{}", Uuid::new_v4())],

--- a/umadb-benches/src/bin/throughput_vs_volume.rs
+++ b/umadb-benches/src/bin/throughput_vs_volume.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::Instant;
 use umadb_client::{AsyncUmaDBClient, UmaDBClient};
-use umadb_dcb::{DCBEvent, DCBEventStoreAsync};
+use umadb_dcb::{DcbEvent, DcbEventStoreAsync};
 use uuid::Uuid;
 
 use clap::{CommandFactory, FromArgMatches, Parser};
@@ -80,8 +80,8 @@ async fn do_some_work(
     // Append 9800 batches of 10 events each
     for _ in 0..99 {
         let tag = format!("tag-{}", Uuid::new_v4());
-        let events: Vec<DCBEvent> = (0..1000)
-            .map(|_| DCBEvent {
+        let events: Vec<DcbEvent> = (0..1000)
+            .map(|_| DcbEvent {
                 event_type: "batch-type".to_string(),
                 data: "batch-data".to_string().into_bytes(),
                 tags: vec![tag.clone()],
@@ -101,7 +101,7 @@ async fn do_some_work(
     let start = Instant::now();
     for _ in 0..1000 {
         let tag = format!("tag-{}", Uuid::new_v4());
-        let event = DCBEvent {
+        let event = DcbEvent {
             event_type: "batch-type".to_string(),
             data: "batch-data".to_string().into_bytes(),
             tags: vec![tag.clone()],

--- a/umadb-benches/src/lib.rs
+++ b/umadb-benches/src/lib.rs
@@ -7,7 +7,7 @@ pub mod bench_api {
     use umadb_core::mvcc::{Mvcc, Writer};
     use umadb_core::node::Node;
     use umadb_core::page::{PAGE_HEADER_SIZE, Page};
-    use umadb_dcb::DCBResult;
+    use umadb_dcb::DcbResult;
 
     /// Minimal public wrapper to allow Criterion benches to measure commit paths
     pub struct BenchDb {
@@ -15,13 +15,13 @@ pub mod bench_api {
     }
 
     impl BenchDb {
-        pub fn new(path: &Path, page_size: usize) -> DCBResult<Self> {
+        pub fn new(path: &Path, page_size: usize) -> DcbResult<Self> {
             let mvcc = Mvcc::new(path, page_size, false)?;
             Ok(BenchDb { mvcc })
         }
 
         /// Commit with no dirty pages: exercises header write + flush.
-        pub fn commit_empty(&self) -> DCBResult<()> {
+        pub fn commit_empty(&self) -> DcbResult<()> {
             let mut w = self.mvcc.writer()?;
             self.mvcc.commit(&mut w)
         }
@@ -30,7 +30,7 @@ pub mod bench_api {
             self.mvcc.writer().unwrap()
         }
 
-        pub fn insert_dirty_pages(&self, w: &mut Writer, n: usize) -> DCBResult<()> {
+        pub fn insert_dirty_pages(&self, w: &mut Writer, n: usize) -> DcbResult<()> {
             // Populate each dirty page with an EventLeaf that has many keys/values
             const KEYS_PER_LEAF: usize = 70; // "lots" of keys/values per leaf
             const TAGS_PER: usize = 3;
@@ -70,7 +70,7 @@ pub mod bench_api {
             Ok(())
         }
 
-        pub fn commit_with_dirty(&self, w: &mut Writer) -> DCBResult<()> {
+        pub fn commit_with_dirty(&self, w: &mut Writer) -> DcbResult<()> {
             self.mvcc.commit(w)
         }
     }
@@ -117,7 +117,7 @@ pub mod bench_api {
             self.last_size
         }
 
-        pub fn deserialize_check(&self) -> DCBResult<EventLeafNode> {
+        pub fn deserialize_check(&self) -> DcbResult<EventLeafNode> {
             let size = self.last_size.min(self.buf.len());
             let out = EventLeafNode::from_slice(&self.buf[..size])?;
             Ok(out)
@@ -166,7 +166,7 @@ pub mod bench_api {
             self.last_size
         }
 
-        pub fn deserialize_check(&self) -> DCBResult<EventLeafNode> {
+        pub fn deserialize_check(&self) -> DcbResult<EventLeafNode> {
             let size = self.last_size.min(self.buf.len());
             let out = EventLeafNode::from_slice(&self.buf[..size])?;
             Ok(out)

--- a/umadb-client/examples/client_async_insecure.rs
+++ b/umadb-client/examples/client_async_insecure.rs
@@ -1,7 +1,7 @@
 use futures::StreamExt;
 use umadb_client::UmaDBClient;
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBEventStoreAsync, DCBQuery, DCBQueryItem,
+    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreAsync, DcbQuery, DcbQueryItem,
     TrackingInfo,
 };
 use uuid::Uuid;
@@ -13,8 +13,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = UmaDBClient::new(url).connect_async().await?;
 
     // Define a consistency boundary
-    let boundary = DCBQuery::new().item(
-        DCBQueryItem::new()
+    let boundary = DcbQuery::new().item(
+        DcbQueryItem::new()
             .types(["example"])
             .tags(["tag1", "tag2"]),
     );
@@ -42,14 +42,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Last known position is: {:?}", last_known_position);
 
     // Produce new event
-    let event = DCBEvent::default()
+    let event = DcbEvent::default()
         .event_type("example")
         .tags(["tag1", "tag2"])
         .data(b"Hello, world!")
         .uuid(Uuid::new_v4());
 
     // Append event in consistency boundary
-    let append_condition = DCBAppendCondition {
+    let append_condition = DcbAppendCondition {
         fail_if_events_match: boundary.clone(),
         after: last_known_position,
     };
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Appended event at position: {}", position1);
 
     // Append conflicting event - expect an error
-    let conflicting_event = DCBEvent::default()
+    let conflicting_event = DcbEvent::default()
         .event_type("example")
         .tags(["tag1", "tag2"])
         .data(b"Hello, world!")
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DCBError::IntegrityError(integrity_error)) => {
+        Err(DdbError::IntegrityError(integrity_error)) => {
             println!("Conflicting event was rejected: {:?}", integrity_error);
         }
         other => panic!("Expected IntegrityError, got {:?}", other),
@@ -148,7 +148,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DCBError::IntegrityError(integrity_error)) => {
+        Err(DdbError::IntegrityError(integrity_error)) => {
             println!(
                 "Conflicting upstream position was rejected: {:?}",
                 integrity_error

--- a/umadb-client/examples/client_async_insecure.rs
+++ b/umadb-client/examples/client_async_insecure.rs
@@ -1,7 +1,7 @@
 use futures::StreamExt;
 use umadb_client::UmaDBClient;
 use umadb_dcb::{
-    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreAsync, DcbQuery, DcbQueryItem,
+    DcbAppendCondition, DcbError, DcbEvent, DcbEventStoreAsync, DcbQuery, DcbQueryItem,
     TrackingInfo,
 };
 use uuid::Uuid;
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DdbError::IntegrityError(integrity_error)) => {
+        Err(DcbError::IntegrityError(integrity_error)) => {
             println!("Conflicting event was rejected: {:?}", integrity_error);
         }
         other => panic!("Expected IntegrityError, got {:?}", other),
@@ -148,7 +148,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DdbError::IntegrityError(integrity_error)) => {
+        Err(DcbError::IntegrityError(integrity_error)) => {
             println!(
                 "Conflicting upstream position was rejected: {:?}",
                 integrity_error

--- a/umadb-client/examples/client_async_secure.rs
+++ b/umadb-client/examples/client_async_secure.rs
@@ -1,7 +1,7 @@
 use futures::StreamExt;
 use umadb_client::UmaDBClient;
 use umadb_dcb::{
-    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreAsync, DcbQuery, DcbQueryItem,
+    DcbAppendCondition, DcbError, DcbEvent, DcbEventStoreAsync, DcbQuery, DcbQueryItem,
     TrackingInfo,
 };
 use uuid::Uuid;
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DdbError::IntegrityError(integrity_error)) => {
+        Err(DcbError::IntegrityError(integrity_error)) => {
             println!("Conflicting event was rejected: {:?}", integrity_error);
         }
         other => panic!("Expected IntegrityError, got {:?}", other),
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DdbError::IntegrityError(integrity_error)) => {
+        Err(DcbError::IntegrityError(integrity_error)) => {
             println!(
                 "Conflicting upstream position was rejected: {:?}",
                 integrity_error

--- a/umadb-client/examples/client_async_secure.rs
+++ b/umadb-client/examples/client_async_secure.rs
@@ -1,7 +1,7 @@
 use futures::StreamExt;
 use umadb_client::UmaDBClient;
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBEventStoreAsync, DCBQuery, DCBQueryItem,
+    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreAsync, DcbQuery, DcbQueryItem,
     TrackingInfo,
 };
 use uuid::Uuid;
@@ -17,8 +17,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Define a consistency boundary
-    let cb = DCBQuery {
-        items: vec![DCBQueryItem {
+    let cb = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec!["example".to_string()],
             tags: vec!["tag1".to_string(), "tag2".to_string()],
         }],
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Last known position is: {:?}", last_known_position);
 
     // Produce new event
-    let event = DCBEvent {
+    let event = DcbEvent {
         event_type: "example".to_string(),
         tags: vec!["tag1".to_string(), "tag2".to_string()],
         data: b"Hello, world!".to_vec(),
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let commit_position1 = client
         .append(
             vec![event.clone()],
-            Some(DCBAppendCondition {
+            Some(DcbAppendCondition {
                 fail_if_events_match: cb.clone(),
                 after: last_known_position,
             }),
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Appended event at position: {}", commit_position1);
 
     // Append conflicting event - expect an error
-    let conflicting_event = DCBEvent {
+    let conflicting_event = DcbEvent {
         event_type: "example".to_string(),
         tags: vec!["tag1".to_string(), "tag2".to_string()],
         data: b"Hello, world!".to_vec(),
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let conflicting_result = client
         .append(
             vec![conflicting_event.clone()],
-            Some(DCBAppendCondition {
+            Some(DcbAppendCondition {
                 fail_if_events_match: cb.clone(),
                 after: last_known_position,
             }),
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DCBError::IntegrityError(integrity_error)) => {
+        Err(DdbError::IntegrityError(integrity_error)) => {
             println!("Conflicting event was rejected: {:?}", integrity_error);
         }
         other => panic!("Expected IntegrityError, got {:?}", other),
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let commit_position2 = client
         .append(
             vec![event.clone()],
-            Some(DCBAppendCondition {
+            Some(DcbAppendCondition {
                 fail_if_events_match: cb.clone(),
                 after: last_known_position,
             }),
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DCBError::IntegrityError(integrity_error)) => {
+        Err(DdbError::IntegrityError(integrity_error)) => {
             println!(
                 "Conflicting upstream position was rejected: {:?}",
                 integrity_error

--- a/umadb-client/examples/client_sync_insecure.rs
+++ b/umadb-client/examples/client_sync_insecure.rs
@@ -1,6 +1,6 @@
 use umadb_client::UmaDBClient;
 use umadb_dcb::{
-    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, TrackingInfo,
+    DcbAppendCondition, DcbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, TrackingInfo,
 };
 use uuid::Uuid;
 
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DdbError::IntegrityError(integrity_error)) => {
+        Err(DcbError::IntegrityError(integrity_error)) => {
             println!("Conflicting event was rejected: {:?}", integrity_error);
         }
         other => panic!("Expected IntegrityError, got {:?}", other),
@@ -133,7 +133,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DdbError::IntegrityError(integrity_error)) => {
+        Err(DcbError::IntegrityError(integrity_error)) => {
             println!(
                 "Conflicting upstream position was rejected: {:?}",
                 integrity_error

--- a/umadb-client/examples/client_sync_insecure.rs
+++ b/umadb-client/examples/client_sync_insecure.rs
@@ -1,6 +1,6 @@
 use umadb_client::UmaDBClient;
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBEventStoreSync, DCBQuery, DCBQueryItem, TrackingInfo,
+    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, TrackingInfo,
 };
 use uuid::Uuid;
 
@@ -10,8 +10,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = UmaDBClient::new(url).connect()?;
 
     // Define a consistency boundary
-    let boundary = DCBQuery::new().item(
-        DCBQueryItem::new()
+    let boundary = DcbQuery::new().item(
+        DcbQueryItem::new()
             .types(["example"])
             .tags(["tag1", "tag2"]),
     );
@@ -37,14 +37,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Last known position is: {:?}", last_known_position);
 
     // Produce new event
-    let event = DCBEvent::default()
+    let event = DcbEvent::default()
         .event_type("example")
         .tags(["tag1", "tag2"])
         .data(b"Hello, world!")
         .uuid(Uuid::new_v4());
 
     // Append event in consistency boundary
-    let append_condition = DCBAppendCondition {
+    let append_condition = DcbAppendCondition {
         fail_if_events_match: boundary.clone(),
         after: last_known_position,
     };
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Appended event at position: {}", position1);
 
     // Append conflicting event - expect an error
-    let conflicting_event = DCBEvent::default()
+    let conflicting_event = DcbEvent::default()
         .event_type("example")
         .tags(["tag1", "tag2"])
         .data(b"Hello, world!")
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DCBError::IntegrityError(integrity_error)) => {
+        Err(DdbError::IntegrityError(integrity_error)) => {
             println!("Conflicting event was rejected: {:?}", integrity_error);
         }
         other => panic!("Expected IntegrityError, got {:?}", other),
@@ -133,7 +133,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DCBError::IntegrityError(integrity_error)) => {
+        Err(DdbError::IntegrityError(integrity_error)) => {
             println!(
                 "Conflicting upstream position was rejected: {:?}",
                 integrity_error

--- a/umadb-client/examples/client_sync_secure.rs
+++ b/umadb-client/examples/client_sync_secure.rs
@@ -1,6 +1,6 @@
 use umadb_client::UmaDBClient;
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBEventStoreSync, DCBQuery, DCBQueryItem, TrackingInfo,
+    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, TrackingInfo,
 };
 use uuid::Uuid;
 
@@ -13,8 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .connect()?;
 
     // Define a consistency boundary
-    let cb = DCBQuery {
-        items: vec![DCBQueryItem {
+    let cb = DcbQuery {
+        items: vec![DcbQueryItem {
             types: vec!["example".to_string()],
             tags: vec!["tag1".to_string(), "tag2".to_string()],
         }],
@@ -41,7 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Last known position is: {:?}", last_known_position);
 
     // Produce new event
-    let event = DCBEvent {
+    let event = DcbEvent {
         event_type: "example".to_string(),
         tags: vec!["tag1".to_string(), "tag2".to_string()],
         data: b"Hello, world!".to_vec(),
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Append event in consistency boundary
     let commit_position1 = client.append(
         vec![event.clone()],
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: cb.clone(),
             after: last_known_position,
         }),
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Appended event at position: {}", commit_position1);
 
     // Append conflicting event - expect an error
-    let conflicting_event = DCBEvent {
+    let conflicting_event = DcbEvent {
         event_type: "example".to_string(),
         tags: vec!["tag1".to_string(), "tag2".to_string()],
         data: b"Hello, world!".to_vec(),
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let conflicting_result = client.append(
         vec![conflicting_event],
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: cb.clone(),
             after: last_known_position,
         }),
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DCBError::IntegrityError(integrity_error)) => {
+        Err(DdbError::IntegrityError(integrity_error)) => {
             println!("Conflicting event was rejected: {:?}", integrity_error);
         }
         other => panic!("Expected IntegrityError, got {:?}", other),
@@ -90,7 +90,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let commit_position2 = client.append(
         vec![event.clone()],
-        Some(DCBAppendCondition {
+        Some(DcbAppendCondition {
             fail_if_events_match: cb.clone(),
             after: last_known_position,
         }),
@@ -153,7 +153,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DCBError::IntegrityError(integrity_error)) => {
+        Err(DdbError::IntegrityError(integrity_error)) => {
             println!(
                 "Conflicting upstream position was rejected: {:?}",
                 integrity_error

--- a/umadb-client/examples/client_sync_secure.rs
+++ b/umadb-client/examples/client_sync_secure.rs
@@ -1,6 +1,6 @@
 use umadb_client::UmaDBClient;
 use umadb_dcb::{
-    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, TrackingInfo,
+    DcbAppendCondition, DcbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, TrackingInfo,
 };
 use uuid::Uuid;
 
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DdbError::IntegrityError(integrity_error)) => {
+        Err(DcbError::IntegrityError(integrity_error)) => {
             println!("Conflicting event was rejected: {:?}", integrity_error);
         }
         other => panic!("Expected IntegrityError, got {:?}", other),
@@ -153,7 +153,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Expect an integrity error
     match conflicting_result {
-        Err(DdbError::IntegrityError(integrity_error)) => {
+        Err(DcbError::IntegrityError(integrity_error)) => {
             println!(
                 "Conflicting upstream position was rejected: {:?}",
                 integrity_error

--- a/umadb-client/src/lib.rs
+++ b/umadb-client/src/lib.rs
@@ -414,7 +414,7 @@ impl AsyncUmaDBClient {
                 let ca_path = PathBuf::from(ca_path);
                 Some(
                     fs::read(&ca_path)
-                        .unwrap_or_else(|_| panic!("Couldn't read cert_path: {:?}", ca_path)),
+                        .unwrap_or_else(|_| panic!("couldn't read cert_path: {:?}", ca_path)),
                 )
             } else {
                 None
@@ -443,10 +443,7 @@ impl AsyncUmaDBClient {
                 tls_enabled,
                 api_key,
             }),
-            Err(err) => Err(DCBError::TransportError(format!(
-                "failed to connect: {:?}",
-                err
-            ))),
+            Err(err) => Err(DCBError::TransportError(format!("{err}"))),
         }
     }
 

--- a/umadb-client/src/lib.rs
+++ b/umadb-client/src/lib.rs
@@ -13,9 +13,9 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint};
 
 use tokio::runtime::{Handle, Runtime};
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBEventStoreAsync, DCBEventStoreSync, DCBQuery,
-    DCBReadResponseAsync, DCBReadResponseSync, DCBResult, DCBSequencedEvent, DCBSubscriptionAsync,
-    DCBSubscriptionSync, TrackingInfo,
+    DcbAppendCondition, DcbEvent, DcbEventStoreAsync, DcbEventStoreSync, DcbQuery,
+    DcbReadResponseAsync, DcbReadResponseSync, DcbResult, DcbSequencedEvent, DcbSubscriptionAsync,
+    DcbSubscriptionSync, DdbError, TrackingInfo,
 };
 
 use std::sync::{Once, OnceLock};
@@ -103,7 +103,7 @@ impl UmaDBClient {
         }
     }
 
-    pub fn connect(&self) -> DCBResult<SyncUmaDBClient> {
+    pub fn connect(&self) -> DcbResult<SyncUmaDBClient> {
         let client = SyncUmaDBClient::connect(
             self.url.clone(),
             self.ca_path.clone(),
@@ -117,7 +117,7 @@ impl UmaDBClient {
         }
         client
     }
-    pub async fn connect_async(&self) -> DCBResult<AsyncUmaDBClient> {
+    pub async fn connect_async(&self) -> DcbResult<AsyncUmaDBClient> {
         let client = AsyncUmaDBClient::connect(
             self.url.clone(),
             self.ca_path.clone(),
@@ -147,9 +147,9 @@ impl SyncUmaDBClient {
     /// The returned iterator yields events indefinitely until cancelled or the stream ends.
     pub fn subscribe(
         &self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         after: Option<u64>,
-    ) -> DCBResult<Box<dyn DCBSubscriptionSync + Send + 'static>> {
+    ) -> DcbResult<Box<dyn DcbSubscriptionSync + Send + 'static>> {
         let async_subscription = self
             .handle
             .block_on(self.async_client.subscribe(query, after))?;
@@ -165,7 +165,7 @@ impl SyncUmaDBClient {
         ca_path: Option<String>,
         batch_size: Option<u32>,
         api_key: Option<String>,
-    ) -> DCBResult<Self> {
+    ) -> DcbResult<Self> {
         let (rt, handle) = Self::get_rt_handle();
         let async_client =
             handle.block_on(AsyncUmaDBClient::connect(url, ca_path, batch_size, api_key))?;
@@ -180,7 +180,7 @@ impl SyncUmaDBClient {
         url: String,
         tls_options: Option<ClientTlsOptions>,
         batch_size: Option<u32>,
-    ) -> DCBResult<Self> {
+    ) -> DcbResult<Self> {
         let (rt, handle) = Self::get_rt_handle();
         let async_client = handle.block_on(AsyncUmaDBClient::connect_with_tls_options(
             url,
@@ -216,15 +216,15 @@ impl SyncUmaDBClient {
     }
 }
 
-impl DCBEventStoreSync for SyncUmaDBClient {
+impl DcbEventStoreSync for SyncUmaDBClient {
     fn read(
         &self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         start: Option<u64>,
         backwards: bool,
         limit: Option<u32>,
         subscribe: bool, // Deprecated - remove in v1.0.
-    ) -> DCBResult<Box<dyn DCBReadResponseSync + Send + 'static>> {
+    ) -> DcbResult<Box<dyn DcbReadResponseSync + Send + 'static>> {
         let async_read_response = self.handle.block_on(
             self.async_client
                 .read(query, start, backwards, limit, subscribe),
@@ -237,21 +237,21 @@ impl DCBEventStoreSync for SyncUmaDBClient {
         }))
     }
 
-    fn head(&self) -> DCBResult<Option<u64>> {
+    fn head(&self) -> DcbResult<Option<u64>> {
         self.handle.block_on(self.async_client.head())
     }
 
-    fn get_tracking_info(&self, source: &str) -> DCBResult<Option<u64>> {
+    fn get_tracking_info(&self, source: &str) -> DcbResult<Option<u64>> {
         self.handle
             .block_on(self.async_client.get_tracking_info(source))
     }
 
     fn append(
         &self,
-        events: Vec<DCBEvent>,
-        condition: Option<DCBAppendCondition>,
+        events: Vec<DcbEvent>,
+        condition: Option<DcbAppendCondition>,
         tracking_info: Option<TrackingInfo>,
-    ) -> DCBResult<u64> {
+    ) -> DcbResult<u64> {
         self.handle
             .block_on(self.async_client.append(events, condition, tracking_info))
     }
@@ -259,14 +259,14 @@ impl DCBEventStoreSync for SyncUmaDBClient {
 
 pub struct SyncClientReadResponse {
     rt: Handle,
-    async_resp: Box<dyn DCBReadResponseAsync + Send + 'static>,
-    buffer: VecDeque<DCBSequencedEvent>, // efficient pop_front()
+    async_resp: Box<dyn DcbReadResponseAsync + Send + 'static>,
+    buffer: VecDeque<DcbSequencedEvent>, // efficient pop_front()
     finished: bool,
 }
 
 impl SyncClientReadResponse {
     /// Fetch the next batch from the async response, filling the buffer
-    fn fetch_next_batch(&mut self) -> DCBResult<()> {
+    fn fetch_next_batch(&mut self) -> DcbResult<()> {
         if self.finished {
             return Ok(());
         }
@@ -282,7 +282,7 @@ impl SyncClientReadResponse {
 }
 
 impl Iterator for SyncClientReadResponse {
-    type Item = DCBResult<DCBSequencedEvent>;
+    type Item = DcbResult<DcbSequencedEvent>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Fetch the next batch if the buffer is empty.
@@ -296,12 +296,12 @@ impl Iterator for SyncClientReadResponse {
     }
 }
 
-impl DCBReadResponseSync for SyncClientReadResponse {
-    fn head(&mut self) -> DCBResult<Option<u64>> {
+impl DcbReadResponseSync for SyncClientReadResponse {
+    fn head(&mut self) -> DcbResult<Option<u64>> {
         self.rt.block_on(self.async_resp.head())
     }
 
-    fn collect_with_head(&mut self) -> DCBResult<(Vec<DCBSequencedEvent>, Option<u64>)> {
+    fn collect_with_head(&mut self) -> DcbResult<(Vec<DcbSequencedEvent>, Option<u64>)> {
         let mut out = Vec::new();
         for result in self.by_ref() {
             out.push(result?);
@@ -309,7 +309,7 @@ impl DCBReadResponseSync for SyncClientReadResponse {
         Ok((out, self.head()?))
     }
 
-    fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>> {
+    fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>> {
         // If there are remaining events in the buffer, drain them
         if !self.buffer.is_empty() {
             return Ok(self.buffer.drain(..).collect());
@@ -323,14 +323,14 @@ impl DCBReadResponseSync for SyncClientReadResponse {
 
 pub struct SyncClientSubscription {
     rt: Handle,
-    async_resp: Box<dyn DCBSubscriptionAsync + Send + 'static>,
-    buffer: VecDeque<DCBSequencedEvent>, // efficient pop_front()
+    async_resp: Box<dyn DcbSubscriptionAsync + Send + 'static>,
+    buffer: VecDeque<DcbSequencedEvent>, // efficient pop_front()
     finished: bool,
 }
 
 impl SyncClientSubscription {
     /// Fetch the next batch from the async response, filling the buffer
-    fn fetch_next_batch(&mut self) -> DCBResult<()> {
+    fn fetch_next_batch(&mut self) -> DcbResult<()> {
         if self.finished {
             return Ok(());
         }
@@ -346,7 +346,7 @@ impl SyncClientSubscription {
 }
 
 impl Iterator for SyncClientSubscription {
-    type Item = DCBResult<DCBSequencedEvent>;
+    type Item = DcbResult<DcbSequencedEvent>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Fetch the next batch if the buffer is empty.
@@ -360,8 +360,8 @@ impl Iterator for SyncClientSubscription {
     }
 }
 
-impl DCBSubscriptionSync for SyncClientSubscription {
-    fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>> {
+impl DcbSubscriptionSync for SyncClientSubscription {
+    fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>> {
         // If there are remaining events in the buffer, drain them
         if !self.buffer.is_empty() {
             return Ok(self.buffer.drain(..).collect());
@@ -384,9 +384,9 @@ pub struct AsyncUmaDBClient {
 impl AsyncUmaDBClient {
     pub async fn subscribe(
         &self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         after: Option<u64>,
-    ) -> DCBResult<Box<dyn DCBSubscriptionAsync + Send + 'static>> {
+    ) -> DcbResult<Box<dyn DcbSubscriptionAsync + Send + 'static>> {
         let query_proto = query.map(|q| q.into());
         let mut client = self.client.clone();
         let req_body = umadb_proto::v1::SubscribeRequest {
@@ -407,7 +407,7 @@ impl AsyncUmaDBClient {
         ca_path: Option<String>,
         batch_size: Option<u32>,
         api_key: Option<String>,
-    ) -> DCBResult<Self> {
+    ) -> DcbResult<Self> {
         // Try to read the CA certificate.
         let ca_pem = {
             if let Some(ca_path) = ca_path {
@@ -434,7 +434,7 @@ impl AsyncUmaDBClient {
         tls_options: Option<ClientTlsOptions>,
         batch_size: Option<u32>,
         api_key: Option<String>,
-    ) -> DCBResult<Self> {
+    ) -> DcbResult<Self> {
         let tls_enabled = url.starts_with("https://") || url.starts_with("grpcs://");
         match new_channel(url, tls_options).await {
             Ok(channel) => Ok(Self {
@@ -443,19 +443,19 @@ impl AsyncUmaDBClient {
                 tls_enabled,
                 api_key,
             }),
-            Err(err) => Err(DCBError::TransportError(format!("{err}"))),
+            Err(err) => Err(DdbError::TransportError(format!("{err}"))),
         }
     }
 
-    fn add_auth<T>(&self, mut req: Request<T>) -> DCBResult<Request<T>> {
+    fn add_auth<T>(&self, mut req: Request<T>) -> DcbResult<Request<T>> {
         if let Some(key) = &self.api_key {
             if !self.tls_enabled {
-                return Err(DCBError::TransportError(
+                return Err(DdbError::TransportError(
                     "API key configured but TLS is not enabled; refusing to send credentials over insecure channel".to_string(),
                 ));
             }
             let token = MetadataValue::from_str(&format!("Bearer {}", key))
-                .map_err(|e| DCBError::TransportError(format!("invalid API key: {}", e)))?;
+                .map_err(|e| DdbError::TransportError(format!("invalid API key: {}", e)))?;
             req.metadata_mut().insert("authorization", token);
         }
         Ok(req)
@@ -467,16 +467,16 @@ impl AsyncUmaDBClient {
 }
 
 #[async_trait]
-impl DCBEventStoreAsync for AsyncUmaDBClient {
+impl DcbEventStoreAsync for AsyncUmaDBClient {
     // Async inherent methods: use the gRPC client directly (no trait required)
     async fn read<'a>(
         &'a self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         start: Option<u64>,
         backwards: bool,
         limit: Option<u32>,
         subscribe: bool,
-    ) -> DCBResult<Box<dyn DCBReadResponseAsync + Send + 'static>> {
+    ) -> DcbResult<Box<dyn DcbReadResponseAsync + Send + 'static>> {
         let query_proto = query.map(|q| q.into());
         let req_body = umadb_proto::v1::ReadRequest {
             query: query_proto,
@@ -496,7 +496,7 @@ impl DCBEventStoreAsync for AsyncUmaDBClient {
         Ok(Box::new(AsyncClientReadResponse::new(stream)))
     }
 
-    async fn head(&self) -> DCBResult<Option<u64>> {
+    async fn head(&self) -> DcbResult<Option<u64>> {
         let mut client = self.client.clone();
         let req = self.add_auth(Request::new(umadb_proto::v1::HeadRequest {}))?;
         match client.head(req).await {
@@ -505,7 +505,7 @@ impl DCBEventStoreAsync for AsyncUmaDBClient {
         }
     }
 
-    async fn get_tracking_info(&self, source: &str) -> DCBResult<Option<u64>> {
+    async fn get_tracking_info(&self, source: &str) -> DcbResult<Option<u64>> {
         let mut client = self.client.clone();
         let req = self.add_auth(Request::new(umadb_proto::v1::TrackingRequest {
             source: source.to_string(),
@@ -518,10 +518,10 @@ impl DCBEventStoreAsync for AsyncUmaDBClient {
 
     async fn append(
         &self,
-        events: Vec<DCBEvent>,
-        condition: Option<DCBAppendCondition>,
+        events: Vec<DcbEvent>,
+        condition: Option<DcbAppendCondition>,
         tracking_info: Option<TrackingInfo>,
-    ) -> DCBResult<u64> {
+    ) -> DcbResult<u64> {
         let events_proto: Vec<umadb_proto::v1::Event> = events
             .into_iter()
             .map(umadb_proto::v1::Event::from)
@@ -551,7 +551,7 @@ impl DCBEventStoreAsync for AsyncUmaDBClient {
 /// Async read response wrapper that provides batched access and head metadata
 pub struct AsyncClientReadResponse {
     stream: tonic::Streaming<umadb_proto::v1::ReadResponse>,
-    buffered: VecDeque<DCBSequencedEvent>,
+    buffered: VecDeque<DcbSequencedEvent>,
     last_head: Option<Option<u64>>, // None = unknown yet; Some(x) = known
     ended: bool,
     cancel: watch::Receiver<()>,
@@ -569,7 +569,7 @@ impl AsyncClientReadResponse {
     }
 
     /// Fetches the next batch if needed, filling the buffer
-    async fn fetch_next_if_needed(&mut self) -> DCBResult<()> {
+    async fn fetch_next_if_needed(&mut self) -> DcbResult<()> {
         if !self.buffered.is_empty() || self.ended {
             return Ok(());
         }
@@ -578,7 +578,7 @@ impl AsyncClientReadResponse {
             _ = self.cancel.changed() => {
                 self.ended = true;
                 // return Ok(());
-                return Err(DCBError::CancelledByUser());
+                return Err(DdbError::CancelledByUser());
             }
             msg = self.stream.message() => {
                 match msg {
@@ -587,8 +587,8 @@ impl AsyncClientReadResponse {
                         let mut buffered = VecDeque::with_capacity(resp.events.len());
                         for e in resp.events {
                             if let Some(ev) = e.event {
-                                let event = DCBEvent::try_from(ev)?;
-                                buffered.push_back(DCBSequencedEvent { position: e.position, event });
+                                let event = DcbEvent::try_from(ev)?;
+                                buffered.push_back(DcbSequencedEvent { position: e.position, event });
                             }
                         }
                         self.buffered = buffered;
@@ -604,8 +604,8 @@ impl AsyncClientReadResponse {
 }
 
 #[async_trait]
-impl DCBReadResponseAsync for AsyncClientReadResponse {
-    async fn head(&mut self) -> DCBResult<Option<u64>> {
+impl DcbReadResponseAsync for AsyncClientReadResponse {
+    async fn head(&mut self) -> DcbResult<Option<u64>> {
         if let Some(h) = self.last_head {
             return Ok(h);
         }
@@ -614,7 +614,7 @@ impl DCBReadResponseAsync for AsyncClientReadResponse {
         Ok(self.last_head.unwrap_or(None))
     }
 
-    async fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>> {
+    async fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>> {
         if !self.buffered.is_empty() {
             return Ok(self.buffered.drain(..).collect());
         }
@@ -630,7 +630,7 @@ impl DCBReadResponseAsync for AsyncClientReadResponse {
 }
 
 impl Stream for AsyncClientReadResponse {
-    type Item = DCBResult<DCBSequencedEvent>;
+    type Item = DcbResult<DcbSequencedEvent>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -655,11 +655,11 @@ impl Stream for AsyncClientReadResponse {
                     for e in resp.events {
                         if let Some(ev) = e.event {
                             // Propagate any conversion error using DCBResult.
-                            let event = match DCBEvent::try_from(ev) {
+                            let event = match DcbEvent::try_from(ev) {
                                 Ok(event) => event,
                                 Err(err) => return Poll::Ready(Some(Err(err))),
                             };
-                            buffered.push_back(DCBSequencedEvent {
+                            buffered.push_back(DcbSequencedEvent {
                                 position: e.position,
                                 event,
                             });
@@ -693,7 +693,7 @@ impl Stream for AsyncClientReadResponse {
 // Async subscribe response wrapper: similar to AsyncClientReadResponse but without head
 pub struct AsyncClientSubscribeResponse {
     stream: tonic::Streaming<umadb_proto::v1::SubscribeResponse>,
-    buffered: VecDeque<DCBSequencedEvent>,
+    buffered: VecDeque<DcbSequencedEvent>,
     ended: bool,
     cancel: watch::Receiver<()>,
 }
@@ -708,7 +708,7 @@ impl AsyncClientSubscribeResponse {
         }
     }
 
-    async fn fetch_next_if_needed(&mut self) -> DCBResult<()> {
+    async fn fetch_next_if_needed(&mut self) -> DcbResult<()> {
         if !self.buffered.is_empty() || self.ended {
             return Ok(());
         }
@@ -716,7 +716,7 @@ impl AsyncClientSubscribeResponse {
         tokio::select! {
             _ = self.cancel.changed() => {
                 self.ended = true;
-                return Err(DCBError::CancelledByUser());
+                return Err(DdbError::CancelledByUser());
             }
             msg = self.stream.message() => {
                 match msg {
@@ -724,8 +724,8 @@ impl AsyncClientSubscribeResponse {
                         let mut buffered = VecDeque::with_capacity(resp.events.len());
                         for e in resp.events {
                             if let Some(ev) = e.event {
-                                let event = DCBEvent::try_from(ev)?;
-                                buffered.push_back(DCBSequencedEvent { position: e.position, event });
+                                let event = DcbEvent::try_from(ev)?;
+                                buffered.push_back(DcbSequencedEvent { position: e.position, event });
                             }
                         }
                         self.buffered = buffered;
@@ -740,8 +740,8 @@ impl AsyncClientSubscribeResponse {
 }
 
 #[async_trait]
-impl DCBSubscriptionAsync for AsyncClientSubscribeResponse {
-    async fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>> {
+impl DcbSubscriptionAsync for AsyncClientSubscribeResponse {
+    async fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>> {
         if !self.buffered.is_empty() {
             return Ok(self.buffered.drain(..).collect());
         }
@@ -754,7 +754,7 @@ impl DCBSubscriptionAsync for AsyncClientSubscribeResponse {
 }
 
 impl Stream for AsyncClientSubscribeResponse {
-    type Item = DCBResult<DCBSequencedEvent>;
+    type Item = DcbResult<DcbSequencedEvent>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -772,11 +772,11 @@ impl Stream for AsyncClientSubscribeResponse {
                     let mut buffered = VecDeque::with_capacity(resp.events.len());
                     for e in resp.events {
                         if let Some(ev) = e.event {
-                            let event = match DCBEvent::try_from(ev) {
+                            let event = match DcbEvent::try_from(ev) {
                                 Ok(event) => event,
                                 Err(err) => return Poll::Ready(Some(Err(err))),
                             };
-                            buffered.push_back(DCBSequencedEvent {
+                            buffered.push_back(DcbSequencedEvent {
                                 position: e.position,
                                 event,
                             });

--- a/umadb-client/src/lib.rs
+++ b/umadb-client/src/lib.rs
@@ -13,9 +13,9 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint};
 
 use tokio::runtime::{Handle, Runtime};
 use umadb_dcb::{
-    DcbAppendCondition, DcbEvent, DcbEventStoreAsync, DcbEventStoreSync, DcbQuery,
+    DcbAppendCondition, DcbError, DcbEvent, DcbEventStoreAsync, DcbEventStoreSync, DcbQuery,
     DcbReadResponseAsync, DcbReadResponseSync, DcbResult, DcbSequencedEvent, DcbSubscriptionAsync,
-    DcbSubscriptionSync, DdbError, TrackingInfo,
+    DcbSubscriptionSync, TrackingInfo,
 };
 
 use std::sync::{Once, OnceLock};
@@ -443,19 +443,19 @@ impl AsyncUmaDBClient {
                 tls_enabled,
                 api_key,
             }),
-            Err(err) => Err(DdbError::TransportError(format!("{err}"))),
+            Err(err) => Err(DcbError::TransportError(format!("{err}"))),
         }
     }
 
     fn add_auth<T>(&self, mut req: Request<T>) -> DcbResult<Request<T>> {
         if let Some(key) = &self.api_key {
             if !self.tls_enabled {
-                return Err(DdbError::TransportError(
+                return Err(DcbError::TransportError(
                     "API key configured but TLS is not enabled; refusing to send credentials over insecure channel".to_string(),
                 ));
             }
             let token = MetadataValue::from_str(&format!("Bearer {}", key))
-                .map_err(|e| DdbError::TransportError(format!("invalid API key: {}", e)))?;
+                .map_err(|e| DcbError::TransportError(format!("invalid API key: {}", e)))?;
             req.metadata_mut().insert("authorization", token);
         }
         Ok(req)
@@ -578,7 +578,7 @@ impl AsyncClientReadResponse {
             _ = self.cancel.changed() => {
                 self.ended = true;
                 // return Ok(());
-                return Err(DdbError::CancelledByUser());
+                return Err(DcbError::CancelledByUser());
             }
             msg = self.stream.message() => {
                 match msg {
@@ -716,7 +716,7 @@ impl AsyncClientSubscribeResponse {
         tokio::select! {
             _ = self.cancel.changed() => {
                 self.ended = true;
-                return Err(DdbError::CancelledByUser());
+                return Err(DcbError::CancelledByUser());
             }
             msg = self.stream.message() => {
                 match msg {

--- a/umadb-core/src/db.rs
+++ b/umadb-core/src/db.rs
@@ -13,8 +13,8 @@ use itertools::Itertools;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use umadb_dcb::{
-    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbReadResponseSync,
-    DcbResult, DcbSequencedEvent, TrackingInfo,
+    DcbAppendCondition, DcbEvent, DcbEventStoreSync, DcbQuery, DcbReadResponseSync, DcbResult,
+    DcbSequencedEvent, DdbError, TrackingInfo,
 };
 use uuid::Uuid;
 
@@ -25,7 +25,7 @@ pub const DEFAULT_DB_FILENAME: &str = "uma.db";
 /// Set to 1 for current releases; previous versions of the code used 0.
 pub const DB_SCHEMA_VERSION: u32 = 1;
 
-/// EventStore implementing the DCBEventStoreSync interface
+/// EventStore implementing the `DcbEventStoreSync` interface
 pub struct UmaDB {
     pub mvcc: Arc<Mvcc>,
 }
@@ -1022,7 +1022,7 @@ mod tests {
     use std::collections::HashMap;
     use tempfile::tempdir;
     use umadb_dcb::{
-        DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem,
+        DcbAppendCondition, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, DdbError,
     };
     use uuid::Uuid;
 

--- a/umadb-core/src/db.rs
+++ b/umadb-core/src/db.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use umadb_dcb::{
     DcbAppendCondition, DcbEvent, DcbEventStoreSync, DcbQuery, DcbReadResponseSync, DcbResult,
-    DcbSequencedEvent, DdbError, TrackingInfo,
+    DcbSequencedEvent, DcbError, TrackingInfo,
 };
 use uuid::Uuid;
 
@@ -67,14 +67,14 @@ impl UmaDB {
                         Err(i) => i,
                     };
                     if idx >= internal.child_ids.len() {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "tracking internal child index out of bounds".to_string(),
                         ));
                     }
                     pid = internal.child_ids[idx];
                 }
                 other => {
-                    return Err(DdbError::DatabaseCorrupted(format!(
+                    return Err(DcbError::DatabaseCorrupted(format!(
                         "Invalid tracking node type: {}",
                         other.type_name()
                     )));
@@ -105,7 +105,7 @@ impl UmaDB {
 
         // Track abort state
         let mut abort_idx: Option<usize> = None;
-        let mut abort_err: Option<DdbError> = None;
+        let mut abort_err: Option<DcbError> = None;
 
         for (idx, (events, condition, tracking)) in items.drain(..).enumerate() {
             if abort_idx.is_some() {
@@ -190,7 +190,7 @@ impl UmaDB {
                                     cond.clone(),
                                     matched,
                                 );
-                                Err(DdbError::IntegrityError(msg))
+                                Err(DcbError::IntegrityError(msg))
                             }
                             Err(err) => {
                                 // Propagate the error for this item but continue with others
@@ -320,7 +320,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
     // Enforce maximum key length (1-byte length field in tracking nodes)
     let key_len = source.len();
     if key_len > u8::MAX as usize {
-        return Err(DdbError::InvalidArgument(format!(
+        return Err(DcbError::InvalidArgument(format!(
             "tracking source too long ({} > 255)",
             key_len
         )));
@@ -351,7 +351,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
             Node::TrackingInternal(internal) => {
                 let child_idx = internal.child_index_for_key(source);
                 if child_idx >= internal.child_ids.len() {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "tracking internal child index out of bounds".to_string(),
                     ));
                 }
@@ -360,7 +360,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
                 current_id = next;
             }
             other => {
-                return Err(DdbError::DatabaseCorrupted(format!(
+                return Err(DcbError::DatabaseCorrupted(format!(
                     "Invalid tracking node type: {}",
                     other.type_name()
                 )));
@@ -372,14 +372,14 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
     {
         let page = writer.get_page_ref(mvcc, current_id)?;
         let Node::TrackingLeaf(leaf) = &page.node else {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Expected TrackingLeaf".to_string(),
             ));
         };
         if let Some(existing) = leaf.get(source)
             && pos.0 <= existing.0
         {
-            return Err(DdbError::IntegrityError(format!(
+            return Err(DcbError::IntegrityError(format!(
                 "non-increasing tracking position for source '{source}': {} <= {}",
                 pos.0, existing.0
             )));
@@ -400,7 +400,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
         // First, insert/update within a limited scope to end the mutable borrow before size checks
         {
             let Node::TrackingLeaf(ref mut node) = leaf_page.node else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Dirty tracking page not a leaf".to_string(),
                 ));
             };
@@ -418,12 +418,12 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
             let right_id: PageID;
             {
                 let Node::TrackingLeaf(ref mut node) = leaf_page.node else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Dirty tracking page not a leaf".to_string(),
                     ));
                 };
                 if node.keys.len() < 2 {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Cannot split tracking leaf with too few keys".to_string(),
                     ));
                 }
@@ -432,7 +432,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
                 let right_vals = node.values.split_off(mid);
                 promoted_key = right_keys
                     .first()
-                    .ok_or_else(|| DdbError::DatabaseCorrupted("empty right split".to_string()))?
+                    .ok_or_else(|| DcbError::DatabaseCorrupted("empty right split".to_string()))?
                     .clone();
                 let right_leaf = TrackingLeafNode {
                     keys: right_keys,
@@ -457,7 +457,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
         if let Some((old_id, new_id)) = replacement_info.take() {
             let parent_page = writer.get_mut_dirty(dirty_parent_id)?;
             let Node::TrackingInternal(ref mut internal) = parent_page.node else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected TrackingInternal".to_string(),
                 ));
             };
@@ -470,7 +470,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
             {
                 let parent_page = writer.get_mut_dirty(dirty_parent_id)?;
                 let Node::TrackingInternal(ref mut internal) = parent_page.node else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected TrackingInternal".to_string(),
                     ));
                 };
@@ -481,7 +481,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
                 // Reborrow mutably to perform the split
                 let parent_page = writer.get_mut_dirty(dirty_parent_id)?;
                 let Node::TrackingInternal(ref mut internal) = parent_page.node else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected TrackingInternal".to_string(),
                     ));
                 };
@@ -507,7 +507,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
         if writer.tracking_tree_root_id == old_id {
             writer.tracking_tree_root_id = new_id;
         } else {
-            return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
+            return Err(DcbError::RootIDMismatch(old_id.0, new_id.0));
         }
     }
 
@@ -964,53 +964,53 @@ pub fn is_request_idempotent(
 }
 
 // --- helpers for append_batch abort policy ---
-pub fn is_integrity_error(e: &DdbError) -> bool {
-    matches!(e, DdbError::IntegrityError(_))
+pub fn is_integrity_error(e: &DcbError) -> bool {
+    matches!(e, DcbError::IntegrityError(_))
 }
 
-pub fn clone_dcb_error(src: &DdbError) -> DdbError {
+pub fn clone_dcb_error(src: &DcbError) -> DcbError {
     match src {
-        DdbError::AuthenticationError(err) => DdbError::AuthenticationError(err.to_string()),
-        DdbError::InitializationError(err) => DdbError::InitializationError(err.to_string()),
-        DdbError::Io(err) => DdbError::Io(std::io::Error::other(err.to_string())),
-        DdbError::IntegrityError(s) => DdbError::IntegrityError(s.clone()),
-        DdbError::Corruption(s) => DdbError::Corruption(s.clone()),
-        DdbError::InvalidArgument(s) => DdbError::InvalidArgument(s.clone()),
-        DdbError::PageNotFound(id) => DdbError::PageNotFound(*id),
-        DdbError::DirtyPageNotFound(id) => DdbError::DirtyPageNotFound(*id),
-        DdbError::RootIDMismatch(old_id, new_id) => DdbError::RootIDMismatch(*old_id, *new_id),
-        DdbError::DatabaseCorrupted(s) => DdbError::DatabaseCorrupted(s.clone()),
-        DdbError::InternalError(s) => DdbError::InternalError(s.clone()),
-        DdbError::SerializationError(s) => DdbError::SerializationError(s.clone()),
-        DdbError::DeserializationError(s) => DdbError::DeserializationError(s.clone()),
-        DdbError::PageAlreadyFreed(id) => DdbError::PageAlreadyFreed(*id),
-        DdbError::PageAlreadyDirty(id) => DdbError::PageAlreadyDirty(*id),
-        DdbError::TransportError(err) => DdbError::TransportError(err.clone()),
-        DdbError::CancelledByUser() => DdbError::CancelledByUser(),
+        DcbError::AuthenticationError(err) => DcbError::AuthenticationError(err.to_string()),
+        DcbError::InitializationError(err) => DcbError::InitializationError(err.to_string()),
+        DcbError::Io(err) => DcbError::Io(std::io::Error::other(err.to_string())),
+        DcbError::IntegrityError(s) => DcbError::IntegrityError(s.clone()),
+        DcbError::Corruption(s) => DcbError::Corruption(s.clone()),
+        DcbError::InvalidArgument(s) => DcbError::InvalidArgument(s.clone()),
+        DcbError::PageNotFound(id) => DcbError::PageNotFound(*id),
+        DcbError::DirtyPageNotFound(id) => DcbError::DirtyPageNotFound(*id),
+        DcbError::RootIDMismatch(old_id, new_id) => DcbError::RootIDMismatch(*old_id, *new_id),
+        DcbError::DatabaseCorrupted(s) => DcbError::DatabaseCorrupted(s.clone()),
+        DcbError::InternalError(s) => DcbError::InternalError(s.clone()),
+        DcbError::SerializationError(s) => DcbError::SerializationError(s.clone()),
+        DcbError::DeserializationError(s) => DcbError::DeserializationError(s.clone()),
+        DcbError::PageAlreadyFreed(id) => DcbError::PageAlreadyFreed(*id),
+        DcbError::PageAlreadyDirty(id) => DcbError::PageAlreadyDirty(*id),
+        DcbError::TransportError(err) => DcbError::TransportError(err.clone()),
+        DcbError::CancelledByUser() => DcbError::CancelledByUser(),
     }
 }
 
-pub fn shadow_for_batch_abort(src: &DdbError) -> DdbError {
+pub fn shadow_for_batch_abort(src: &DcbError) -> DcbError {
     let msg = "batch aborted due to internal error".to_string();
     match src {
-        DdbError::AuthenticationError(_) => DdbError::AuthenticationError(msg),
-        DdbError::InitializationError(_) => DdbError::InitializationError(msg),
-        DdbError::Io(_) => DdbError::Io(std::io::Error::other(msg)),
-        DdbError::IntegrityError(_) => DdbError::IntegrityError(msg),
-        DdbError::Corruption(_) => DdbError::Corruption(msg),
-        DdbError::InvalidArgument(_) => DdbError::InvalidArgument(msg),
-        DdbError::DatabaseCorrupted(_) => DdbError::DatabaseCorrupted(msg),
-        DdbError::InternalError(_) => DdbError::InternalError(msg),
-        DdbError::SerializationError(_) => DdbError::SerializationError(msg),
-        DdbError::DeserializationError(_) => DdbError::DeserializationError(msg),
-        DdbError::TransportError(_) => DdbError::TransportError(msg),
+        DcbError::AuthenticationError(_) => DcbError::AuthenticationError(msg),
+        DcbError::InitializationError(_) => DcbError::InitializationError(msg),
+        DcbError::Io(_) => DcbError::Io(std::io::Error::other(msg)),
+        DcbError::IntegrityError(_) => DcbError::IntegrityError(msg),
+        DcbError::Corruption(_) => DcbError::Corruption(msg),
+        DcbError::InvalidArgument(_) => DcbError::InvalidArgument(msg),
+        DcbError::DatabaseCorrupted(_) => DcbError::DatabaseCorrupted(msg),
+        DcbError::InternalError(_) => DcbError::InternalError(msg),
+        DcbError::SerializationError(_) => DcbError::SerializationError(msg),
+        DcbError::DeserializationError(_) => DcbError::DeserializationError(msg),
+        DcbError::TransportError(_) => DcbError::TransportError(msg),
         // For numeric/marker variants, we cannot add a message; keep same variant to preserve type
-        DdbError::PageNotFound(id) => DdbError::PageNotFound(*id),
-        DdbError::DirtyPageNotFound(id) => DdbError::DirtyPageNotFound(*id),
-        DdbError::RootIDMismatch(a, b) => DdbError::RootIDMismatch(*a, *b),
-        DdbError::PageAlreadyFreed(id) => DdbError::PageAlreadyFreed(*id),
-        DdbError::PageAlreadyDirty(id) => DdbError::PageAlreadyDirty(*id),
-        DdbError::CancelledByUser() => DdbError::CancelledByUser(),
+        DcbError::PageNotFound(id) => DcbError::PageNotFound(*id),
+        DcbError::DirtyPageNotFound(id) => DcbError::DirtyPageNotFound(*id),
+        DcbError::RootIDMismatch(a, b) => DcbError::RootIDMismatch(*a, *b),
+        DcbError::PageAlreadyFreed(id) => DcbError::PageAlreadyFreed(*id),
+        DcbError::PageAlreadyDirty(id) => DcbError::PageAlreadyDirty(*id),
+        DcbError::CancelledByUser() => DcbError::CancelledByUser(),
     }
 }
 
@@ -1022,7 +1022,7 @@ mod tests {
     use std::collections::HashMap;
     use tempfile::tempdir;
     use umadb_dcb::{
-        DcbAppendCondition, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, DdbError,
+        DcbAppendCondition, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, DcbError,
     };
     use uuid::Uuid;
 
@@ -1056,7 +1056,7 @@ mod tests {
             )
             .unwrap_err();
         match err {
-            DdbError::InvalidArgument(msg) => assert!(msg.contains("too long")),
+            DcbError::InvalidArgument(msg) => assert!(msg.contains("too long")),
             other => panic!("unexpected error: {:?}", other),
         }
     }
@@ -1221,7 +1221,7 @@ mod tests {
             .err()
             .expect("expected error");
         match err {
-            DdbError::IntegrityError(msg) => {
+            DcbError::IntegrityError(msg) => {
                 assert!(msg.contains("non-increasing tracking position"))
             }
             other => panic!("unexpected error: {:?}", other),
@@ -1836,7 +1836,7 @@ mod tests {
             None,
         );
         match res {
-            Err(DdbError::IntegrityError(_)) => {}
+            Err(DcbError::IntegrityError(_)) => {}
             other => panic!("Expected IntegrityError, got {:?}", other),
         }
         // Ensure head unchanged after failed append
@@ -1899,7 +1899,7 @@ mod tests {
         // Second item should fail integrity
         match &results[1] {
             Ok(pos) => panic!("expected integrity error, got Ok({})", pos),
-            Err(e) => assert!(matches!(e, DdbError::IntegrityError(_))),
+            Err(e) => assert!(matches!(e, DcbError::IntegrityError(_))),
         }
         // Third item should succeed with last position 2 (since second didn't append)
         match &results[2] {
@@ -1979,7 +1979,7 @@ mod tests {
         }
         match &results[1] {
             Ok(pos) => panic!("expected integrity error, got Ok({})", pos),
-            Err(e) => assert!(matches!(e, DdbError::IntegrityError(_))),
+            Err(e) => assert!(matches!(e, DcbError::IntegrityError(_))),
         }
         match &results[2] {
             Ok(pos) => assert_eq!(*pos, 2),
@@ -2095,7 +2095,7 @@ mod tests {
             other => panic!("unexpected for item0: {:?}", other),
         }
         match &results[1] {
-            Err(DdbError::IntegrityError(_)) => {}
+            Err(DcbError::IntegrityError(_)) => {}
             other => {
                 panic!("expected IntegrityError for item1, got {:?}", other)
             }
@@ -2105,7 +2105,7 @@ mod tests {
             other => panic!("unexpected for item2: {:?}", other),
         }
         match &results[3] {
-            Err(DdbError::IntegrityError(_)) => {}
+            Err(DcbError::IntegrityError(_)) => {}
             other => {
                 panic!("expected IntegrityError for item3, got {:?}", other)
             }
@@ -2234,7 +2234,7 @@ mod tests {
             other => panic!("unexpected for item0: {:?}", other),
         }
         match &results[1] {
-            Err(DdbError::IntegrityError(_)) => {}
+            Err(DcbError::IntegrityError(_)) => {}
             other => {
                 panic!("expected IntegrityError for item1, got {:?}", other)
             }
@@ -2244,7 +2244,7 @@ mod tests {
             other => panic!("unexpected for item2: {:?}", other),
         }
         match &results[3] {
-            Err(DdbError::IntegrityError(_)) => {}
+            Err(DcbError::IntegrityError(_)) => {}
             other => {
                 panic!("expected IntegrityError for item3, got {:?}", other)
             }
@@ -2368,7 +2368,7 @@ mod tests {
 
         // Try with event2 and condition1 - should get an error.
         let result = store.append(vec![event2.clone()], condition1.clone(), None);
-        assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+        assert!(matches!(result, Err(DcbError::IntegrityError(_))));
 
         // Try with two events in different order - should get an error.
         let result = store.append(
@@ -2376,7 +2376,7 @@ mod tests {
             condition1.clone(),
             None,
         );
-        assert!(matches!(result, Err(DdbError::IntegrityError(_))));
+        assert!(matches!(result, Err(DcbError::IntegrityError(_))));
     }
 
     #[test]

--- a/umadb-core/src/db.rs
+++ b/umadb-core/src/db.rs
@@ -13,8 +13,8 @@ use itertools::Itertools;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBEventStoreSync, DCBQuery, DCBReadResponseSync,
-    DCBResult, DCBSequencedEvent, TrackingInfo,
+    DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbReadResponseSync,
+    DcbResult, DcbSequencedEvent, TrackingInfo,
 };
 use uuid::Uuid;
 
@@ -33,7 +33,7 @@ pub struct UmaDB {
 impl UmaDB {
     /// Create a new EventStore at the given directory or file path.
     /// If a directory path is provided, a file named "uma.db" will be used inside it.
-    pub fn new<P: AsRef<Path>>(path: P) -> DCBResult<Self> {
+    pub fn new<P: AsRef<Path>>(path: P) -> DcbResult<Self> {
         let p = path.as_ref();
         let file_path = if p.is_dir() {
             p.join(DEFAULT_DB_FILENAME)
@@ -51,7 +51,7 @@ impl UmaDB {
     }
 
     /// Returns the greatest recorded upstream position for a source, if any.
-    pub fn get_tracking_info(&self, source: &str) -> DCBResult<Option<u64>> {
+    pub fn get_tracking_info(&self, source: &str) -> DcbResult<Option<u64>> {
         let reader = self.mvcc.reader()?;
         let mut pid = reader.tracking_tree_root_id;
         if pid == PageID(0) {
@@ -67,14 +67,14 @@ impl UmaDB {
                         Err(i) => i,
                     };
                     if idx >= internal.child_ids.len() {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "tracking internal child index out of bounds".to_string(),
                         ));
                     }
                     pid = internal.child_ids[idx];
                 }
                 other => {
-                    return Err(DCBError::DatabaseCorrupted(format!(
+                    return Err(DdbError::DatabaseCorrupted(format!(
                         "Invalid tracking node type: {}",
                         other.type_name()
                     )));
@@ -93,19 +93,19 @@ impl UmaDB {
     pub fn append_batch(
         &self,
         mut items: Vec<(
-            Vec<DCBEvent>,
-            Option<DCBAppendCondition>,
+            Vec<DcbEvent>,
+            Option<DcbAppendCondition>,
             Option<TrackingInfo>,
         )>,
-    ) -> DCBResult<Vec<DCBResult<u64>>> {
+    ) -> DcbResult<Vec<DcbResult<u64>>> {
         let total = items.len();
         let mvcc = &self.mvcc;
         let mut writer = mvcc.writer()?;
-        let mut results: Vec<DCBResult<u64>> = Vec::with_capacity(total);
+        let mut results: Vec<DcbResult<u64>> = Vec::with_capacity(total);
 
         // Track abort state
         let mut abort_idx: Option<usize> = None;
-        let mut abort_err: Option<DCBError> = None;
+        let mut abort_err: Option<DdbError> = None;
 
         for (idx, (events, condition, tracking)) in items.drain(..).enumerate() {
             if abort_idx.is_some() {
@@ -148,12 +148,12 @@ impl UmaDB {
     }
 
     pub fn process_append_request(
-        events: Vec<DCBEvent>,
-        condition: Option<DCBAppendCondition>,
+        events: Vec<DcbEvent>,
+        condition: Option<DcbAppendCondition>,
         tracking_info: Option<TrackingInfo>,
         mvcc: &Arc<Mvcc>,
         writer: &mut Writer,
-    ) -> DCBResult<u64> {
+    ) -> DcbResult<u64> {
         // Check condition using read_conditional (limit 1), starting after the provided position
         if let Some(cond) = condition {
             let from = cond.after.map(|after| Position(after + 1));
@@ -190,7 +190,7 @@ impl UmaDB {
                                     cond.clone(),
                                     matched,
                                 );
-                                Err(DCBError::IntegrityError(msg))
+                                Err(DdbError::IntegrityError(msg))
                             }
                             Err(err) => {
                                 // Propagate the error for this item but continue with others
@@ -229,15 +229,15 @@ impl UmaDB {
     }
 }
 
-impl DCBEventStoreSync for UmaDB {
+impl DcbEventStoreSync for UmaDB {
     fn read(
         &self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         start: Option<u64>,
         backwards: bool,
         limit: Option<u32>,
         _subscribe: bool, // Deprecated - remove in v1.0.
-    ) -> DCBResult<Box<dyn DCBReadResponseSync + Send + 'static>> {
+    ) -> DcbResult<Box<dyn DcbReadResponseSync + Send + 'static>> {
         let mvcc = &self.mvcc;
         let reader = mvcc.reader()?;
 
@@ -245,7 +245,7 @@ impl DCBEventStoreSync for UmaDB {
         let last_committed_position = reader.next_position.0.saturating_sub(1);
 
         // Build query and after
-        let q = query.unwrap_or(DCBQuery { items: vec![] });
+        let q = query.unwrap_or(DcbQuery { items: vec![] });
         let from = start.map(Position);
 
         // Delegate to read_conditional
@@ -278,14 +278,14 @@ impl DCBEventStoreSync for UmaDB {
         }))
     }
 
-    fn head(&self) -> DCBResult<Option<u64>> {
+    fn head(&self) -> DcbResult<Option<u64>> {
         let db = &self.mvcc;
         let (_, header) = db.get_latest_header()?;
         let last = header.next_position.0.saturating_sub(1);
         if last == 0 { Ok(None) } else { Ok(Some(last)) }
     }
 
-    fn get_tracking_info(&self, source: &str) -> DCBResult<Option<u64>> {
+    fn get_tracking_info(&self, source: &str) -> DcbResult<Option<u64>> {
         UmaDB::get_tracking_info(self, source)
     }
 
@@ -294,10 +294,10 @@ impl DCBEventStoreSync for UmaDB {
     /// any recorded for the given source, and atomically updates the tracking leaf.
     fn append(
         &self,
-        events: Vec<DCBEvent>,
-        condition: Option<DCBAppendCondition>,
+        events: Vec<DcbEvent>,
+        condition: Option<DcbAppendCondition>,
         tracking_info: Option<TrackingInfo>,
-    ) -> DCBResult<u64> {
+    ) -> DcbResult<u64> {
         if events.is_empty() {
             return Ok(0);
         }
@@ -311,16 +311,16 @@ impl DCBEventStoreSync for UmaDB {
 }
 
 struct ReadResponse {
-    events: VecDeque<DCBSequencedEvent>,
+    events: VecDeque<DcbSequencedEvent>,
     head: Option<u64>,
 }
 
 /// Ensure tracking constraint and update/insert the position into leaf without splitting.
-fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position) -> DCBResult<()> {
+fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position) -> DcbResult<()> {
     // Enforce maximum key length (1-byte length field in tracking nodes)
     let key_len = source.len();
     if key_len > u8::MAX as usize {
-        return Err(DCBError::InvalidArgument(format!(
+        return Err(DdbError::InvalidArgument(format!(
             "tracking source too long ({} > 255)",
             key_len
         )));
@@ -351,7 +351,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
             Node::TrackingInternal(internal) => {
                 let child_idx = internal.child_index_for_key(source);
                 if child_idx >= internal.child_ids.len() {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "tracking internal child index out of bounds".to_string(),
                     ));
                 }
@@ -360,7 +360,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
                 current_id = next;
             }
             other => {
-                return Err(DCBError::DatabaseCorrupted(format!(
+                return Err(DdbError::DatabaseCorrupted(format!(
                     "Invalid tracking node type: {}",
                     other.type_name()
                 )));
@@ -372,14 +372,14 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
     {
         let page = writer.get_page_ref(mvcc, current_id)?;
         let Node::TrackingLeaf(leaf) = &page.node else {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Expected TrackingLeaf".to_string(),
             ));
         };
         if let Some(existing) = leaf.get(source)
             && pos.0 <= existing.0
         {
-            return Err(DCBError::IntegrityError(format!(
+            return Err(DdbError::IntegrityError(format!(
                 "non-increasing tracking position for source '{source}': {} <= {}",
                 pos.0, existing.0
             )));
@@ -400,7 +400,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
         // First, insert/update within a limited scope to end the mutable borrow before size checks
         {
             let Node::TrackingLeaf(ref mut node) = leaf_page.node else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Dirty tracking page not a leaf".to_string(),
                 ));
             };
@@ -418,12 +418,12 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
             let right_id: PageID;
             {
                 let Node::TrackingLeaf(ref mut node) = leaf_page.node else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Dirty tracking page not a leaf".to_string(),
                     ));
                 };
                 if node.keys.len() < 2 {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Cannot split tracking leaf with too few keys".to_string(),
                     ));
                 }
@@ -432,7 +432,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
                 let right_vals = node.values.split_off(mid);
                 promoted_key = right_keys
                     .first()
-                    .ok_or_else(|| DCBError::DatabaseCorrupted("empty right split".to_string()))?
+                    .ok_or_else(|| DdbError::DatabaseCorrupted("empty right split".to_string()))?
                     .clone();
                 let right_leaf = TrackingLeafNode {
                     keys: right_keys,
@@ -457,7 +457,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
         if let Some((old_id, new_id)) = replacement_info.take() {
             let parent_page = writer.get_mut_dirty(dirty_parent_id)?;
             let Node::TrackingInternal(ref mut internal) = parent_page.node else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected TrackingInternal".to_string(),
                 ));
             };
@@ -470,7 +470,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
             {
                 let parent_page = writer.get_mut_dirty(dirty_parent_id)?;
                 let Node::TrackingInternal(ref mut internal) = parent_page.node else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected TrackingInternal".to_string(),
                     ));
                 };
@@ -481,7 +481,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
                 // Reborrow mutably to perform the split
                 let parent_page = writer.get_mut_dirty(dirty_parent_id)?;
                 let Node::TrackingInternal(ref mut internal) = parent_page.node else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected TrackingInternal".to_string(),
                     ));
                 };
@@ -507,7 +507,7 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
         if writer.tracking_tree_root_id == old_id {
             writer.tracking_tree_root_id = new_id;
         } else {
-            return Err(DCBError::RootIDMismatch(old_id.0, new_id.0));
+            return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
         }
     }
 
@@ -528,21 +528,21 @@ fn tracking_upsert(mvcc: &Mvcc, writer: &mut Writer, source: &str, pos: Position
 }
 
 impl Iterator for ReadResponse {
-    type Item = DCBResult<DCBSequencedEvent>;
+    type Item = DcbResult<DcbSequencedEvent>;
     fn next(&mut self) -> Option<Self::Item> {
         self.events.pop_front().map(Ok)
     }
 }
 
-impl DCBReadResponseSync for ReadResponse {
-    fn head(&mut self) -> DCBResult<Option<u64>> {
+impl DcbReadResponseSync for ReadResponse {
+    fn head(&mut self) -> DcbResult<Option<u64>> {
         Ok(self.head)
     }
-    fn collect_with_head(&mut self) -> DCBResult<(Vec<DCBSequencedEvent>, Option<u64>)> {
+    fn collect_with_head(&mut self) -> DcbResult<(Vec<DcbSequencedEvent>, Option<u64>)> {
         let events = self.events.drain(..).collect();
         Ok((events, self.head))
     }
-    fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>> {
+    fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>> {
         let batch = self.events.drain(..).collect();
         Ok(batch)
     }
@@ -559,8 +559,8 @@ impl DCBReadResponseSync for ReadResponse {
 pub fn unconditional_append(
     mvcc: &Mvcc,
     writer: &mut Writer,
-    events: Vec<DCBEvent>,
-) -> DCBResult<u64> {
+    events: Vec<DcbEvent>,
+) -> DcbResult<u64> {
     // Note: when used with tracking, the caller must perform tracking checks and updates
     // before this call within the same writer to ensure atomicity.
     let mut last_pos_u64: u64 = 0;
@@ -592,12 +592,12 @@ pub fn read_conditional(
     dirty: &HashMap<PageID, Page>,
     events_tree_root_id: PageID,
     tags_tree_root_id: PageID,
-    query: DCBQuery,
+    query: DcbQuery,
     start: Option<Position>,
     backwards: bool,
     limit: Option<u32>,
     force_sequential_read: bool,
-) -> DCBResult<Vec<DCBSequencedEvent>> {
+) -> DcbResult<Vec<DcbSequencedEvent>> {
     const SCAN_BATCH_SIZE: u32 = 256;
     // Special case: explicit zero limit
     if let Some(0) = limit {
@@ -607,16 +607,16 @@ pub fn read_conditional(
     // If no items, return all events with after/limit respected via sequential scan
     if query.items.is_empty() {
         let mut iter = EventIterator::new(mvcc, dirty, events_tree_root_id, start, backwards);
-        let mut out: Vec<DCBSequencedEvent> = Vec::new();
+        let mut out: Vec<DcbSequencedEvent> = Vec::new();
         'outer_all: loop {
             let batch = iter.next_batch(limit.unwrap_or(SCAN_BATCH_SIZE))?;
             if batch.is_empty() {
                 break;
             }
             for (pos, rec) in batch.into_iter() {
-                out.push(DCBSequencedEvent {
+                out.push(DcbSequencedEvent {
                     position: pos.0,
-                    event: DCBEvent {
+                    event: DcbEvent {
                         event_type: rec.event_type,
                         data: rec.data,
                         tags: rec.tags,
@@ -638,7 +638,7 @@ pub fn read_conditional(
     if !all_items_have_tags || force_sequential_read {
         // Fallback: sequentially scan all events and apply the same matching logic
         let mut iter = EventIterator::new(mvcc, dirty, events_tree_root_id, start, backwards);
-        let mut out: Vec<DCBSequencedEvent> = Vec::new();
+        let mut out: Vec<DcbSequencedEvent> = Vec::new();
         let matches_item = |rec: &EventRecord| -> bool {
             for item in &query.items {
                 let type_ok =
@@ -660,9 +660,9 @@ pub fn read_conditional(
             }
             for (pos, rec) in batch.into_iter() {
                 if matches_item(&rec) {
-                    out.push(DCBSequencedEvent {
+                    out.push(DcbSequencedEvent {
                         position: pos.0,
-                        event: DCBEvent {
+                        event: DcbEvent {
                             event_type: rec.event_type,
                             data: rec.data,
                             tags: rec.tags,
@@ -800,7 +800,7 @@ pub fn read_conditional(
         }
     }
 
-    let mut out: Vec<DCBSequencedEvent> = Vec::new();
+    let mut out: Vec<DcbSequencedEvent> = Vec::new();
     for (pos, tags_present, qiis_present) in GroupByPositionIterator::new(merged) {
         // Find any query item whose required tag set is subset of tags_present
         let matching_qiis: Vec<usize> = qiis_present
@@ -835,9 +835,9 @@ pub fn read_conditional(
             continue;
         }
 
-        out.push(DCBSequencedEvent {
+        out.push(DcbSequencedEvent {
             position: pos.0,
-            event: DCBEvent {
+            event: DcbEvent {
                 event_type: rec.event_type,
                 data: rec.data,
                 tags: rec.tags,
@@ -905,10 +905,10 @@ pub fn is_request_idempotent(
     dirty: &HashMap<PageID, Page>,
     events_tree_root_id: PageID,
     tags_tree_root_id: PageID,
-    events: &Vec<DCBEvent>,
-    fail_if_events_match: DCBQuery,
+    events: &Vec<DcbEvent>,
+    fail_if_events_match: DcbQuery,
     start: Option<Position>,
-) -> DCBResult<Option<u64>> {
+) -> DcbResult<Option<u64>> {
     // Check events for event IDs. If all have events IDs then
     // call read_conditional again with limit=event.len() and then
     // see if all events have matching UUIDs.
@@ -964,53 +964,53 @@ pub fn is_request_idempotent(
 }
 
 // --- helpers for append_batch abort policy ---
-pub fn is_integrity_error(e: &DCBError) -> bool {
-    matches!(e, DCBError::IntegrityError(_))
+pub fn is_integrity_error(e: &DdbError) -> bool {
+    matches!(e, DdbError::IntegrityError(_))
 }
 
-pub fn clone_dcb_error(src: &DCBError) -> DCBError {
+pub fn clone_dcb_error(src: &DdbError) -> DdbError {
     match src {
-        DCBError::AuthenticationError(err) => DCBError::AuthenticationError(err.to_string()),
-        DCBError::InitializationError(err) => DCBError::InitializationError(err.to_string()),
-        DCBError::Io(err) => DCBError::Io(std::io::Error::other(err.to_string())),
-        DCBError::IntegrityError(s) => DCBError::IntegrityError(s.clone()),
-        DCBError::Corruption(s) => DCBError::Corruption(s.clone()),
-        DCBError::InvalidArgument(s) => DCBError::InvalidArgument(s.clone()),
-        DCBError::PageNotFound(id) => DCBError::PageNotFound(*id),
-        DCBError::DirtyPageNotFound(id) => DCBError::DirtyPageNotFound(*id),
-        DCBError::RootIDMismatch(old_id, new_id) => DCBError::RootIDMismatch(*old_id, *new_id),
-        DCBError::DatabaseCorrupted(s) => DCBError::DatabaseCorrupted(s.clone()),
-        DCBError::InternalError(s) => DCBError::InternalError(s.clone()),
-        DCBError::SerializationError(s) => DCBError::SerializationError(s.clone()),
-        DCBError::DeserializationError(s) => DCBError::DeserializationError(s.clone()),
-        DCBError::PageAlreadyFreed(id) => DCBError::PageAlreadyFreed(*id),
-        DCBError::PageAlreadyDirty(id) => DCBError::PageAlreadyDirty(*id),
-        DCBError::TransportError(err) => DCBError::TransportError(err.clone()),
-        DCBError::CancelledByUser() => DCBError::CancelledByUser(),
+        DdbError::AuthenticationError(err) => DdbError::AuthenticationError(err.to_string()),
+        DdbError::InitializationError(err) => DdbError::InitializationError(err.to_string()),
+        DdbError::Io(err) => DdbError::Io(std::io::Error::other(err.to_string())),
+        DdbError::IntegrityError(s) => DdbError::IntegrityError(s.clone()),
+        DdbError::Corruption(s) => DdbError::Corruption(s.clone()),
+        DdbError::InvalidArgument(s) => DdbError::InvalidArgument(s.clone()),
+        DdbError::PageNotFound(id) => DdbError::PageNotFound(*id),
+        DdbError::DirtyPageNotFound(id) => DdbError::DirtyPageNotFound(*id),
+        DdbError::RootIDMismatch(old_id, new_id) => DdbError::RootIDMismatch(*old_id, *new_id),
+        DdbError::DatabaseCorrupted(s) => DdbError::DatabaseCorrupted(s.clone()),
+        DdbError::InternalError(s) => DdbError::InternalError(s.clone()),
+        DdbError::SerializationError(s) => DdbError::SerializationError(s.clone()),
+        DdbError::DeserializationError(s) => DdbError::DeserializationError(s.clone()),
+        DdbError::PageAlreadyFreed(id) => DdbError::PageAlreadyFreed(*id),
+        DdbError::PageAlreadyDirty(id) => DdbError::PageAlreadyDirty(*id),
+        DdbError::TransportError(err) => DdbError::TransportError(err.clone()),
+        DdbError::CancelledByUser() => DdbError::CancelledByUser(),
     }
 }
 
-pub fn shadow_for_batch_abort(src: &DCBError) -> DCBError {
+pub fn shadow_for_batch_abort(src: &DdbError) -> DdbError {
     let msg = "batch aborted due to internal error".to_string();
     match src {
-        DCBError::AuthenticationError(_) => DCBError::AuthenticationError(msg),
-        DCBError::InitializationError(_) => DCBError::InitializationError(msg),
-        DCBError::Io(_) => DCBError::Io(std::io::Error::other(msg)),
-        DCBError::IntegrityError(_) => DCBError::IntegrityError(msg),
-        DCBError::Corruption(_) => DCBError::Corruption(msg),
-        DCBError::InvalidArgument(_) => DCBError::InvalidArgument(msg),
-        DCBError::DatabaseCorrupted(_) => DCBError::DatabaseCorrupted(msg),
-        DCBError::InternalError(_) => DCBError::InternalError(msg),
-        DCBError::SerializationError(_) => DCBError::SerializationError(msg),
-        DCBError::DeserializationError(_) => DCBError::DeserializationError(msg),
-        DCBError::TransportError(_) => DCBError::TransportError(msg),
+        DdbError::AuthenticationError(_) => DdbError::AuthenticationError(msg),
+        DdbError::InitializationError(_) => DdbError::InitializationError(msg),
+        DdbError::Io(_) => DdbError::Io(std::io::Error::other(msg)),
+        DdbError::IntegrityError(_) => DdbError::IntegrityError(msg),
+        DdbError::Corruption(_) => DdbError::Corruption(msg),
+        DdbError::InvalidArgument(_) => DdbError::InvalidArgument(msg),
+        DdbError::DatabaseCorrupted(_) => DdbError::DatabaseCorrupted(msg),
+        DdbError::InternalError(_) => DdbError::InternalError(msg),
+        DdbError::SerializationError(_) => DdbError::SerializationError(msg),
+        DdbError::DeserializationError(_) => DdbError::DeserializationError(msg),
+        DdbError::TransportError(_) => DdbError::TransportError(msg),
         // For numeric/marker variants, we cannot add a message; keep same variant to preserve type
-        DCBError::PageNotFound(id) => DCBError::PageNotFound(*id),
-        DCBError::DirtyPageNotFound(id) => DCBError::DirtyPageNotFound(*id),
-        DCBError::RootIDMismatch(a, b) => DCBError::RootIDMismatch(*a, *b),
-        DCBError::PageAlreadyFreed(id) => DCBError::PageAlreadyFreed(*id),
-        DCBError::PageAlreadyDirty(id) => DCBError::PageAlreadyDirty(*id),
-        DCBError::CancelledByUser() => DCBError::CancelledByUser(),
+        DdbError::PageNotFound(id) => DdbError::PageNotFound(*id),
+        DdbError::DirtyPageNotFound(id) => DdbError::DirtyPageNotFound(*id),
+        DdbError::RootIDMismatch(a, b) => DdbError::RootIDMismatch(*a, *b),
+        DdbError::PageAlreadyFreed(id) => DdbError::PageAlreadyFreed(*id),
+        DdbError::PageAlreadyDirty(id) => DdbError::PageAlreadyDirty(*id),
+        DdbError::CancelledByUser() => DdbError::CancelledByUser(),
     }
 }
 
@@ -1022,7 +1022,7 @@ mod tests {
     use std::collections::HashMap;
     use tempfile::tempdir;
     use umadb_dcb::{
-        DCBAppendCondition, DCBError, DCBEvent, DCBEventStoreSync, DCBQuery, DCBQueryItem,
+        DcbAppendCondition, DdbError, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem,
     };
     use uuid::Uuid;
 
@@ -1044,7 +1044,7 @@ mod tests {
         let uma = UmaDB::new(db_path).unwrap();
         // Make a 256-byte ASCII string
         let long_key = "a".repeat(256);
-        let ev = DCBEvent::new().event_type("T").data([1u8]);
+        let ev = DcbEvent::new().event_type("T").data([1u8]);
         let err = uma
             .append(
                 vec![ev],
@@ -1056,7 +1056,7 @@ mod tests {
             )
             .unwrap_err();
         match err {
-            DCBError::InvalidArgument(msg) => assert!(msg.contains("too long")),
+            DdbError::InvalidArgument(msg) => assert!(msg.contains("too long")),
             other => panic!("unexpected error: {:?}", other),
         }
     }
@@ -1070,7 +1070,7 @@ mod tests {
         let mvcc = Mvcc::new(&db_path, 256, false).unwrap();
         let uma = UmaDB::from_arc(Arc::new(mvcc));
 
-        let base_event = DCBEvent::new().event_type("T").data([0u8]);
+        let base_event = DcbEvent::new().event_type("T").data([0u8]);
         // Insert many different sources to force at least one leaf split
         for i in 0..50u32 {
             let key = format!("k{:03}", i);
@@ -1101,7 +1101,7 @@ mod tests {
         let mvcc = Mvcc::new(&db_path, 128, false).unwrap();
         let uma = UmaDB::from_arc(Arc::new(mvcc));
 
-        let base_event = DCBEvent::new().event_type("T").data([0u8]);
+        let base_event = DcbEvent::new().event_type("T").data([0u8]);
 
         // Keep track of every key we send and the expected value (position)
         let mut observed: HashMap<String, u64> = HashMap::new();
@@ -1189,7 +1189,7 @@ mod tests {
         let uma = UmaDB::new(db_path).unwrap();
 
         // Prepare a simple event
-        let ev = DCBEvent::new()
+        let ev = DcbEvent::new()
             .event_type("T1")
             .data(vec![1, 2, 3])
             .tags(["x", "y"]);
@@ -1221,7 +1221,7 @@ mod tests {
             .err()
             .expect("expected error");
         match err {
-            DCBError::IntegrityError(msg) => {
+            DdbError::IntegrityError(msg) => {
                 assert!(msg.contains("non-increasing tracking position"))
             }
             other => panic!("unexpected error: {:?}", other),
@@ -1247,11 +1247,11 @@ mod tests {
         mvcc: &Mvcc,
         events_tree_root_id: PageID,
         tags_tree_root_id: PageID,
-        query: DCBQuery,
+        query: DcbQuery,
         start: Option<Position>,
         backwards: bool,
         limit: Option<u32>,
-    ) -> DCBResult<Vec<DCBSequencedEvent>> {
+    ) -> DcbResult<Vec<DcbSequencedEvent>> {
         super::read_conditional(
             mvcc,
             &HashMap::<PageID, Page>::new(),
@@ -1268,7 +1268,7 @@ mod tests {
     static VERBOSE: bool = false;
 
     // Helper to produce a deterministic set of 10 events with shared tags and unique types
-    fn standard_events() -> Vec<DCBEvent> {
+    fn standard_events() -> Vec<DcbEvent> {
         let shared_tags = vec![
             "alpha".to_string(),
             "beta".to_string(),
@@ -1276,11 +1276,11 @@ mod tests {
             "delta".to_string(),
             "epsilon".to_string(),
         ];
-        let mut input: Vec<DCBEvent> = Vec::new();
+        let mut input: Vec<DcbEvent> = Vec::new();
         for i in 0..10u8 {
             let t1 = shared_tags[(i % 5) as usize].clone();
             let t2 = shared_tags[((i + 2) % 5) as usize].clone();
-            input.push(DCBEvent {
+            input.push(DcbEvent {
                 event_type: format!("Type{}", i),
                 data: vec![i, i + 1, i + 2],
                 tags: vec![t1, t2],
@@ -1291,7 +1291,7 @@ mod tests {
     }
 
     // Create DB with the standard events; keep temp dir alive by returning it
-    fn setup_db_with_standard_events() -> (tempfile::TempDir, Mvcc, Vec<DCBEvent>) {
+    fn setup_db_with_standard_events() -> (tempfile::TempDir, Mvcc, Vec<DcbEvent>) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("mvcc-api-test.db");
         let db = Mvcc::new(db_path.as_ref(), DEFAULT_PAGE_SIZE, VERBOSE).unwrap();
@@ -1318,7 +1318,7 @@ mod tests {
             &mut mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             Some(Position(1)),
             false,
             None,
@@ -1333,7 +1333,7 @@ mod tests {
             &mut mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             Some(Position(first + 1)),
             false,
             None,
@@ -1347,7 +1347,7 @@ mod tests {
             &mut mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             Some(Position(last + 1)),
             false,
             None,
@@ -1360,7 +1360,7 @@ mod tests {
             &mut mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             Some(Position(1)),
             false,
             Some(0),
@@ -1371,7 +1371,7 @@ mod tests {
             &mut mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             Some(Position(1)),
             false,
             Some(3),
@@ -1382,7 +1382,7 @@ mod tests {
             &mut mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             Some(Position(1)),
             false,
             Some(20),
@@ -1395,8 +1395,8 @@ mod tests {
     #[serial]
     fn tags_only_single_tag_after_and_limit() {
         let (_tmp, mut db, _input) = setup_db_with_standard_events();
-        let qi = DCBQuery {
-            items: vec![DCBQueryItem {
+        let qi = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec![],
                 tags: vec!["alpha".to_string()],
             }],
@@ -1484,8 +1484,8 @@ mod tests {
     #[serial]
     fn tags_only_multi_tag_and() {
         let (_tmp, mut db, _input) = setup_db_with_standard_events();
-        let qi = DCBQuery {
-            items: vec![DCBQueryItem {
+        let qi = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec![],
                 tags: vec!["alpha".to_string(), "gamma".to_string()],
             }],
@@ -1516,8 +1516,8 @@ mod tests {
     #[serial]
     fn types_plus_tags_index_path() {
         let (_tmp, mut db, _input) = setup_db_with_standard_events();
-        let qi = DCBQuery {
-            items: vec![DCBQueryItem {
+        let qi = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec!["Type0".to_string()],
                 tags: vec!["alpha".to_string()],
             }],
@@ -1542,8 +1542,8 @@ mod tests {
     #[serial]
     fn or_semantics_and_deduplication() {
         let (_tmp, mut db, _input) = setup_db_with_standard_events();
-        let alpha_only = DCBQuery {
-            items: vec![DCBQueryItem {
+        let alpha_only = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec![],
                 tags: vec!["alpha".to_string()],
             }],
@@ -1564,13 +1564,13 @@ mod tests {
         .collect();
 
         // Overlapping items: alpha OR (alpha AND gamma) should deduplicate
-        let query = DCBQuery {
+        let query = DcbQuery {
             items: vec![
-                DCBQueryItem {
+                DcbQueryItem {
                     types: vec![],
                     tags: vec!["alpha".to_string()],
                 },
-                DCBQueryItem {
+                DcbQueryItem {
                     types: vec![],
                     tags: vec!["alpha".to_string(), "gamma".to_string()],
                 },
@@ -1599,19 +1599,19 @@ mod tests {
 
         // Use a smaller custom set to make counts obvious
         let events = vec![
-            DCBEvent {
+            DcbEvent {
                 event_type: "TypeA".to_string(),
                 data: vec![1],
                 tags: vec!["x".to_string()],
                 uuid: None,
             },
-            DCBEvent {
+            DcbEvent {
                 event_type: "TypeB".to_string(),
                 data: vec![2],
                 tags: vec!["y".to_string()],
                 uuid: None,
             },
-            DCBEvent {
+            DcbEvent {
                 event_type: "TypeA".to_string(),
                 data: vec![3],
                 tags: vec!["z".to_string()],
@@ -1626,8 +1626,8 @@ mod tests {
         assert_eq!(last, head);
 
         // Query item with no tags => forces fallback path; select TypeA only
-        let qi = DCBQuery {
-            items: vec![DCBQueryItem {
+        let qi = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec!["TypeA".to_string()],
                 tags: vec![],
             }],
@@ -1679,8 +1679,8 @@ mod tests {
     fn fallback_empty_item_matches_all() {
         let (_tmp, mut db, input) = setup_db_with_standard_events();
         // An empty item (no types, no tags) should match all events via fallback path
-        let qi = DCBQuery {
-            items: vec![DCBQueryItem {
+        let qi = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec![],
                 tags: vec![],
             }],
@@ -1736,13 +1736,13 @@ mod tests {
 
         // Append a couple of events
         let events = vec![
-            DCBEvent {
+            DcbEvent {
                 event_type: "TypeA".to_string(),
                 data: vec![1],
                 tags: vec!["foo".to_string()],
                 uuid: None,
             },
-            DCBEvent {
+            DcbEvent {
                 event_type: "TypeB".to_string(),
                 data: vec![2],
                 tags: vec!["bar".to_string(), "foo".to_string()],
@@ -1769,8 +1769,8 @@ mod tests {
         assert_eq!(head_lim1, Some(only_one[0].position));
 
         // Tag-filtered read ("foo")
-        let query = DCBQuery {
-            items: vec![DCBQueryItem {
+        let query = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec![],
                 tags: vec!["foo".to_string()],
             }],
@@ -1790,9 +1790,9 @@ mod tests {
         assert_eq!(out3[0].event.event_type, "TypeB");
 
         // Append with a condition that should PASS: query matches existing 'foo' but after = last
-        let cond_pass = DCBAppendCondition {
-            fail_if_events_match: DCBQuery {
-                items: vec![DCBQueryItem {
+        let cond_pass = DcbAppendCondition {
+            fail_if_events_match: DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec!["foo".to_string()],
                 }],
@@ -1801,7 +1801,7 @@ mod tests {
         };
         let ok_last = store
             .append(
-                vec![DCBEvent {
+                vec![DcbEvent {
                     event_type: "TypeC".to_string(),
                     data: vec![3],
                     tags: vec!["baz".to_string()],
@@ -1815,9 +1815,9 @@ mod tests {
         assert_eq!(store.head().unwrap(), Some(ok_last));
 
         // Append with a condition that should FAIL: same query but after = 0
-        let cond_fail = DCBAppendCondition {
-            fail_if_events_match: DCBQuery {
-                items: vec![DCBQueryItem {
+        let cond_fail = DcbAppendCondition {
+            fail_if_events_match: DcbQuery {
+                items: vec![DcbQueryItem {
                     types: vec![],
                     tags: vec!["foo".to_string()],
                 }],
@@ -1826,7 +1826,7 @@ mod tests {
         };
         let before_head = store.head().unwrap();
         let res = store.append(
-            vec![DCBEvent {
+            vec![DcbEvent {
                 event_type: "TypeD".to_string(),
                 data: vec![4],
                 tags: vec!["qux".to_string()],
@@ -1836,7 +1836,7 @@ mod tests {
             None,
         );
         match res {
-            Err(DCBError::IntegrityError(_)) => {}
+            Err(DdbError::IntegrityError(_)) => {}
             other => panic!("Expected IntegrityError, got {:?}", other),
         }
         // Ensure head unchanged after failed append
@@ -1848,19 +1848,19 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let store = UmaDB::new(temp_dir.path()).unwrap();
 
-        let e1 = DCBEvent {
+        let e1 = DcbEvent {
             event_type: "A".into(),
             data: b"1".to_vec(),
             tags: vec!["t1".into()],
             uuid: None,
         };
-        let e2 = DCBEvent {
+        let e2 = DcbEvent {
             event_type: "B".into(),
             data: b"2".to_vec(),
             tags: vec!["t2".into()],
             uuid: None,
         };
-        let e3 = DCBEvent {
+        let e3 = DcbEvent {
             event_type: "C".into(),
             data: b"3".to_vec(),
             tags: vec!["t3".into()],
@@ -1872,16 +1872,16 @@ mod tests {
             (vec![e1.clone()], None, None),
             (
                 vec![e2.clone()],
-                Some(DCBAppendCondition {
-                    fail_if_events_match: DCBQuery::default(),
+                Some(DcbAppendCondition {
+                    fail_if_events_match: DcbQuery::default(),
                     after: None,
                 }),
                 None,
             ),
             (
                 vec![e3.clone()],
-                Some(DCBAppendCondition {
-                    fail_if_events_match: DCBQuery::default(),
+                Some(DcbAppendCondition {
+                    fail_if_events_match: DcbQuery::default(),
                     after: Some(10),
                 }),
                 None,
@@ -1899,7 +1899,7 @@ mod tests {
         // Second item should fail integrity
         match &results[1] {
             Ok(pos) => panic!("expected integrity error, got Ok({})", pos),
-            Err(e) => assert!(matches!(e, DCBError::IntegrityError(_))),
+            Err(e) => assert!(matches!(e, DdbError::IntegrityError(_))),
         }
         // Third item should succeed with last position 2 (since second didn't append)
         match &results[2] {
@@ -1921,27 +1921,27 @@ mod tests {
         let store = UmaDB::new(temp_dir.path()).unwrap();
 
         // Item1 introduces tag "x"; Item2 condition queries tag "x" and must see it via dirty tags tree; Item3 uses after to ignore it
-        let e1 = DCBEvent {
+        let e1 = DcbEvent {
             event_type: "T".into(),
             data: b"one".to_vec(),
             tags: vec!["x".into()],
             uuid: None,
         };
-        let e2 = DCBEvent {
+        let e2 = DcbEvent {
             event_type: "T".into(),
             data: b"two".to_vec(),
             tags: vec!["y".into()],
             uuid: None,
         };
-        let e3 = DCBEvent {
+        let e3 = DcbEvent {
             event_type: "T".into(),
             data: b"three".to_vec(),
             tags: vec!["z".into()],
             uuid: None,
         };
 
-        let query_tag_x = DCBQuery {
-            items: vec![DCBQueryItem {
+        let query_tag_x = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec![],
                 tags: vec!["x".into()],
             }],
@@ -1953,7 +1953,7 @@ mod tests {
             // 2) Attempt append e2, but fail if any events with tag x exist after None (i.e., from the start); should fail due to e1 in dirty pages
             (
                 vec![e2.clone()],
-                Some(DCBAppendCondition {
+                Some(DcbAppendCondition {
                     fail_if_events_match: query_tag_x.clone(),
                     after: None,
                 }),
@@ -1962,7 +1962,7 @@ mod tests {
             // 3) Append e3 with condition that ignores position 1 by using after=Some(1); should pass
             (
                 vec![e3.clone()],
-                Some(DCBAppendCondition {
+                Some(DcbAppendCondition {
                     fail_if_events_match: query_tag_x.clone(),
                     after: Some(1),
                 }),
@@ -1979,7 +1979,7 @@ mod tests {
         }
         match &results[1] {
             Ok(pos) => panic!("expected integrity error, got Ok({})", pos),
-            Err(e) => assert!(matches!(e, DCBError::IntegrityError(_))),
+            Err(e) => assert!(matches!(e, DdbError::IntegrityError(_))),
         }
         match &results[2] {
             Ok(pos) => assert_eq!(*pos, 2),
@@ -2007,7 +2007,7 @@ mod tests {
         let store = UmaDB::new(temp_dir.path()).unwrap();
 
         // Prepare events
-        let small = DCBEvent {
+        let small = DcbEvent {
             event_type: "S".into(),
             data: b"sm".to_vec(),
             tags: vec!["tS".into()],
@@ -2015,25 +2015,25 @@ mod tests {
         };
         // Large data to ensure it spills into event overflow pages
         let big_data_len = DEFAULT_PAGE_SIZE * 3; // 3 pages worth to be safe
-        let big = DCBEvent {
+        let big = DcbEvent {
             event_type: "B".into(),
             data: vec![0xAB; big_data_len],
             tags: vec!["tB".into()],
             uuid: None,
         };
-        let filler1 = DCBEvent {
+        let filler1 = DcbEvent {
             event_type: "X".into(),
             data: b"x".to_vec(),
             tags: vec![],
             uuid: None,
         };
-        let filler2 = DCBEvent {
+        let filler2 = DcbEvent {
             event_type: "Y".into(),
             data: b"y".to_vec(),
             tags: vec![],
             uuid: None,
         };
-        let final_ok = DCBEvent {
+        let final_ok = DcbEvent {
             event_type: "C".into(),
             data: b"c".to_vec(),
             tags: vec![],
@@ -2041,14 +2041,14 @@ mod tests {
         };
 
         // Queries by type only (no tags) to force fallback path over events tree (which reads from dirty pages)
-        let q_type_s = DCBQuery {
-            items: vec![DCBQueryItem {
+        let q_type_s = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec!["S".into()],
                 tags: vec![],
             }],
         };
-        let q_type_b = DCBQuery {
-            items: vec![DCBQueryItem {
+        let q_type_b = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec!["B".into()],
                 tags: vec![],
             }],
@@ -2060,7 +2060,7 @@ mod tests {
             // 2) Should fail because type S exists in dirty pages (after None)
             (
                 vec![filler1.clone()],
-                Some(DCBAppendCondition {
+                Some(DcbAppendCondition {
                     fail_if_events_match: q_type_s.clone(),
                     after: None,
                 }),
@@ -2071,7 +2071,7 @@ mod tests {
             // 4) Should fail because type B exists in dirty pages (after None)
             (
                 vec![filler2.clone()],
-                Some(DCBAppendCondition {
+                Some(DcbAppendCondition {
                     fail_if_events_match: q_type_b.clone(),
                     after: None,
                 }),
@@ -2080,7 +2080,7 @@ mod tests {
             // 5) Should succeed because after=Some(2) ignores positions <= 2 (small at 1, big at 2)
             (
                 vec![final_ok.clone()],
-                Some(DCBAppendCondition {
+                Some(DcbAppendCondition {
                     fail_if_events_match: q_type_b.clone(),
                     after: Some(2),
                 }),
@@ -2095,7 +2095,7 @@ mod tests {
             other => panic!("unexpected for item0: {:?}", other),
         }
         match &results[1] {
-            Err(DCBError::IntegrityError(_)) => {}
+            Err(DdbError::IntegrityError(_)) => {}
             other => {
                 panic!("expected IntegrityError for item1, got {:?}", other)
             }
@@ -2105,7 +2105,7 @@ mod tests {
             other => panic!("unexpected for item2: {:?}", other),
         }
         match &results[3] {
-            Err(DCBError::IntegrityError(_)) => {}
+            Err(DdbError::IntegrityError(_)) => {}
             other => {
                 panic!("expected IntegrityError for item3, got {:?}", other)
             }
@@ -2145,7 +2145,7 @@ mod tests {
         let store = UmaDB::new(temp_dir.path()).unwrap();
 
         // Small inline event: type "S" with tag "x"
-        let small = DCBEvent {
+        let small = DcbEvent {
             event_type: "S".into(),
             data: b"sm".to_vec(),
             tags: vec!["x".into()],
@@ -2153,26 +2153,26 @@ mod tests {
         };
         // Big overflow event: type "B" with tag "y" and large payload to exercise overflow pages
         let big_data_len = DEFAULT_PAGE_SIZE * 3; // ensure multiple overflow pages
-        let big = DCBEvent {
+        let big = DcbEvent {
             event_type: "B".into(),
             data: vec![0xCD; big_data_len],
             tags: vec!["y".into()],
             uuid: None,
         };
         // Fillers that will be conditioned out
-        let filler1 = DCBEvent {
+        let filler1 = DcbEvent {
             event_type: "X".into(),
             data: b"x".to_vec(),
             tags: vec![],
             uuid: None,
         };
-        let filler2 = DCBEvent {
+        let filler2 = DcbEvent {
             event_type: "Y".into(),
             data: b"y".to_vec(),
             tags: vec![],
             uuid: None,
         };
-        let final_ok = DCBEvent {
+        let final_ok = DcbEvent {
             event_type: "C".into(),
             data: b"c".to_vec(),
             tags: vec![],
@@ -2180,14 +2180,14 @@ mod tests {
         };
 
         // Conditions combining tags and types so the tags index is used and the type filter applies after lookup
-        let q_s_and_x = DCBQuery {
-            items: vec![DCBQueryItem {
+        let q_s_and_x = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec!["S".into()],
                 tags: vec!["x".into()],
             }],
         };
-        let q_b_and_y = DCBQuery {
-            items: vec![DCBQueryItem {
+        let q_b_and_y = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec!["B".into()],
                 tags: vec!["y".into()],
             }],
@@ -2199,7 +2199,7 @@ mod tests {
             // 2) Should fail because S@x exists in dirty pages (tags path + type filter)
             (
                 vec![filler1.clone()],
-                Some(DCBAppendCondition {
+                Some(DcbAppendCondition {
                     fail_if_events_match: q_s_and_x.clone(),
                     after: None,
                 }),
@@ -2210,7 +2210,7 @@ mod tests {
             // 4) Should fail because B@y exists in dirty pages (tags path + type filter and overflow read)
             (
                 vec![filler2.clone()],
-                Some(DCBAppendCondition {
+                Some(DcbAppendCondition {
                     fail_if_events_match: q_b_and_y.clone(),
                     after: None,
                 }),
@@ -2219,7 +2219,7 @@ mod tests {
             // 5) Should succeed because after=Some(2) ignores positions <= 2 (small at 1, big at 2)
             (
                 vec![final_ok.clone()],
-                Some(DCBAppendCondition {
+                Some(DcbAppendCondition {
                     fail_if_events_match: q_b_and_y.clone(),
                     after: Some(2),
                 }),
@@ -2234,7 +2234,7 @@ mod tests {
             other => panic!("unexpected for item0: {:?}", other),
         }
         match &results[1] {
-            Err(DCBError::IntegrityError(_)) => {}
+            Err(DdbError::IntegrityError(_)) => {}
             other => {
                 panic!("expected IntegrityError for item1, got {:?}", other)
             }
@@ -2244,7 +2244,7 @@ mod tests {
             other => panic!("unexpected for item2: {:?}", other),
         }
         match &results[3] {
-            Err(DCBError::IntegrityError(_)) => {}
+            Err(DdbError::IntegrityError(_)) => {}
             other => {
                 panic!("expected IntegrityError for item3, got {:?}", other)
             }
@@ -2285,12 +2285,12 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let store = UmaDB::new(temp_dir.path()).unwrap();
 
-        let condition1 = Some(DCBAppendCondition {
-            fail_if_events_match: DCBQuery { items: vec![] },
+        let condition1 = Some(DcbAppendCondition {
+            fail_if_events_match: DcbQuery { items: vec![] },
             after: None,
         });
 
-        let event1 = DCBEvent {
+        let event1 = DcbEvent {
             event_type: "type1".to_string(),
             data: b"data1".to_vec(),
             tags: vec!["tag1".to_string()],
@@ -2322,7 +2322,7 @@ mod tests {
         assert_eq!(event1.uuid, result[0].event.uuid);
 
         // Append another event.
-        let event2 = DCBEvent {
+        let event2 = DcbEvent {
             event_type: "type2".to_string(),
             data: b"data2".to_vec(),
             tags: vec!["tag2".to_string()],
@@ -2368,7 +2368,7 @@ mod tests {
 
         // Try with event2 and condition1 - should get an error.
         let result = store.append(vec![event2.clone()], condition1.clone(), None);
-        assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+        assert!(matches!(result, Err(DdbError::IntegrityError(_))));
 
         // Try with two events in different order - should get an error.
         let result = store.append(
@@ -2376,7 +2376,7 @@ mod tests {
             condition1.clone(),
             None,
         );
-        assert!(matches!(result, Err(DCBError::IntegrityError(_))));
+        assert!(matches!(result, Err(DdbError::IntegrityError(_))));
     }
 
     #[test]
@@ -2390,7 +2390,7 @@ mod tests {
             &mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             Some(Position(1)),
             false,
             None,
@@ -2405,7 +2405,7 @@ mod tests {
             &mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             None,
             true,
             None,
@@ -2422,7 +2422,7 @@ mod tests {
             &mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             Some(Position(last)),
             true,
             None,
@@ -2436,7 +2436,7 @@ mod tests {
             &mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             Some(Position(last - 1)),
             true,
             None,
@@ -2451,7 +2451,7 @@ mod tests {
             &mvcc,
             reader.events_tree_root_id,
             reader.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             None,
             true,
             Some(3),
@@ -2466,8 +2466,8 @@ mod tests {
     fn tags_only_single_tag_backwards() {
         let (_tmp, mvcc, _input) = setup_db_with_standard_events();
         let reader = mvcc.reader().unwrap();
-        let qi = DCBQuery {
-            items: vec![DCBQueryItem {
+        let qi = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec![],
                 tags: vec!["alpha".to_string()],
             }],
@@ -2524,8 +2524,8 @@ mod tests {
     fn tags_only_multi_tag_and_backwards() {
         let (_tmp, db, _input) = setup_db_with_standard_events();
         let reader = db.reader().unwrap();
-        let qi = DCBQuery {
-            items: vec![DCBQueryItem {
+        let qi = DcbQuery {
+            items: vec![DcbQueryItem {
                 types: vec![],
                 tags: vec!["alpha".to_string(), "gamma".to_string()],
             }],
@@ -2622,13 +2622,13 @@ mod tests {
         let (_tmp, db, _input) = setup_db_with_standard_events();
         let reader = db.reader().unwrap();
         // Two items: (alpha & gamma) OR (beta & delta)
-        let qi = DCBQuery {
+        let qi = DcbQuery {
             items: vec![
-                DCBQueryItem {
+                DcbQueryItem {
                     types: vec![],
                     tags: vec!["alpha".to_string(), "gamma".to_string()],
                 },
-                DCBQueryItem {
+                DcbQueryItem {
                     types: vec![],
                     tags: vec!["beta".to_string(), "delta".to_string()],
                 },

--- a/umadb-core/src/events_tree.rs
+++ b/umadb-core/src/events_tree.rs
@@ -8,14 +8,14 @@ use crate::node::Node;
 use crate::page::{PAGE_HEADER_SIZE, Page};
 use std::borrow::Cow;
 use std::collections::HashMap;
-use umadb_dcb::{DCBError, DCBResult};
+use umadb_dcb::{DdbError, DcbResult};
 
 // Helpers for storing large event data across overflow pages
-fn write_overflow_chain(mvcc: &Mvcc, writer: &mut Writer, data: &[u8]) -> DCBResult<PageID> {
+fn write_overflow_chain(mvcc: &Mvcc, writer: &mut Writer, data: &[u8]) -> DcbResult<PageID> {
     // Maximum payload per overflow page: page_size - header - next pointer (8 bytes)
     let payload_cap = mvcc.page_size.saturating_sub(PAGE_HEADER_SIZE + 8);
     if payload_cap == 0 {
-        return Err(DCBError::DatabaseCorrupted(
+        return Err(DdbError::DatabaseCorrupted(
             "Page size too small to store overflow data".to_string(),
         ));
     }
@@ -57,7 +57,7 @@ fn read_overflow_chain(
     mvcc: &Mvcc,
     dirty: &HashMap<PageID, Page>,
     mut page_id: PageID,
-) -> DCBResult<Vec<u8>> {
+) -> DcbResult<Vec<u8>> {
     let mut out: Vec<u8> = Vec::new();
     while page_id.0 != 0 {
         // Prefer the dirty (unflushed) page if present; otherwise read from disk
@@ -72,7 +72,7 @@ fn read_overflow_chain(
                 page_id = node.next;
             }
             _ => {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected EventOverflow node".to_string(),
                 ));
             }
@@ -85,7 +85,7 @@ fn materialize_event_value(
     mvcc: &Mvcc,
     dirty: &HashMap<PageID, Page>,
     value: &EventValue,
-) -> DCBResult<EventRecord> {
+) -> DcbResult<EventRecord> {
     match value {
         EventValue::Inline(rec) => Ok(rec.clone()),
         EventValue::Overflow {
@@ -97,7 +97,7 @@ fn materialize_event_value(
         } => {
             let data = read_overflow_chain(mvcc, dirty, *root_id)?;
             if (data.len() as u64) != *data_len {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Overflow data length mismatch".to_string(),
                 ));
             }
@@ -121,7 +121,7 @@ pub fn event_tree_append(
     writer: &mut Writer,
     event: EventRecord,
     position: Position,
-) -> DCBResult<()> {
+) -> DcbResult<()> {
     let verbose = mvcc.verbose;
     if verbose {
         println!("Appending event: {position:?} {event:?}");
@@ -147,7 +147,7 @@ pub fn event_tree_append(
                 .last()
                 .expect("Internal node should have some children");
         } else {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Expected EventInternal node".to_string(),
             ));
         }
@@ -205,14 +205,14 @@ pub fn event_tree_append(
                         }
                         popped = Some((last_key, last_value));
                     } else {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Expected EventLeaf node".to_string(),
                         ));
                     }
                 }
             }
             _ => {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected EventLeaf node at event tree root".to_string(),
                 ));
             }
@@ -295,7 +295,7 @@ pub fn event_tree_append(
                 println!("Nothing to replace in {dirty_page_id:?}")
             }
         } else {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Expected EventInternal node".to_string(),
             ));
         }
@@ -312,7 +312,7 @@ pub fn event_tree_append(
                     );
                 }
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected EventInternal node".to_string(),
                 ));
             }
@@ -328,7 +328,7 @@ pub fn event_tree_append(
                 // Split the internal node
                 // Ensure we have at least 3 keys and 4 child IDs before splitting
                 if dirty_internal_node.keys.len() < 3 || dirty_internal_node.child_ids.len() < 4 {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Cannot split internal node with too few keys/children".to_string(),
                     ));
                 }
@@ -367,7 +367,7 @@ pub fn event_tree_append(
 
                 split_info = Some((promoted_key, new_internal_page_id));
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected EventInternal node".to_string(),
                 ));
             }
@@ -384,7 +384,7 @@ pub fn event_tree_append(
                 println!("Replaced root {old_id:?} with {new_id:?}");
             }
         } else {
-            return Err(DCBError::RootIDMismatch(old_id.0, new_id.0));
+            return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
         }
     }
 
@@ -416,7 +416,7 @@ pub fn event_tree_lookup(
     dirty: &HashMap<PageID, Page>,
     events_tree_root_id: PageID,
     position: Position,
-) -> DCBResult<EventRecord> {
+) -> DcbResult<EventRecord> {
     let mut current_page_id: PageID = events_tree_root_id;
     loop {
         // Prefer the dirty (unflushed) page if present; otherwise read from disk
@@ -433,7 +433,7 @@ pub fn event_tree_lookup(
                     Err(i) => i,
                 };
                 if idx >= internal.child_ids.len() {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Child index out of bounds in event tree".to_string(),
                     ));
                 }
@@ -445,13 +445,13 @@ pub fn event_tree_lookup(
                         let rec = materialize_event_value(mvcc, dirty, &leaf.values[i])?;
                         Ok(rec)
                     }
-                    Err(_) => Err(DCBError::DatabaseCorrupted(format!(
+                    Err(_) => Err(DdbError::DatabaseCorrupted(format!(
                         "Event at position {position:?} not found",
                     ))),
                 };
             }
             _ => {
-                return Err(DCBError::DatabaseCorrupted(format!(
+                return Err(DdbError::DatabaseCorrupted(format!(
                     "Expected EventInternal or EventLeaf node in event tree, got {}",
                     page.node.type_name()
                 )));
@@ -488,7 +488,7 @@ impl<'a> EventIterator<'a> {
         }
     }
 
-    pub fn next_batch(&mut self, batch_size: u32) -> DCBResult<Vec<(Position, EventRecord)>> {
+    pub fn next_batch(&mut self, batch_size: u32) -> DcbResult<Vec<(Position, EventRecord)>> {
         let mut result: Vec<(Position, EventRecord)> = Vec::with_capacity(batch_size as usize);
         if batch_size == 0 {
             return Ok(result);
@@ -649,7 +649,7 @@ impl<'a> EventIterator<'a> {
                         }
                     }
                     _ => {
-                        return Err(DCBError::DatabaseCorrupted(format!(
+                        return Err(DdbError::DatabaseCorrupted(format!(
                             "Expected EventInternal or EventLeaf node in event tree, got {}",
                             page_ref.node.type_name()
                         )));

--- a/umadb-core/src/events_tree.rs
+++ b/umadb-core/src/events_tree.rs
@@ -8,14 +8,14 @@ use crate::node::Node;
 use crate::page::{PAGE_HEADER_SIZE, Page};
 use std::borrow::Cow;
 use std::collections::HashMap;
-use umadb_dcb::{DdbError, DcbResult};
+use umadb_dcb::{DcbError, DcbResult};
 
 // Helpers for storing large event data across overflow pages
 fn write_overflow_chain(mvcc: &Mvcc, writer: &mut Writer, data: &[u8]) -> DcbResult<PageID> {
     // Maximum payload per overflow page: page_size - header - next pointer (8 bytes)
     let payload_cap = mvcc.page_size.saturating_sub(PAGE_HEADER_SIZE + 8);
     if payload_cap == 0 {
-        return Err(DdbError::DatabaseCorrupted(
+        return Err(DcbError::DatabaseCorrupted(
             "Page size too small to store overflow data".to_string(),
         ));
     }
@@ -72,7 +72,7 @@ fn read_overflow_chain(
                 page_id = node.next;
             }
             _ => {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected EventOverflow node".to_string(),
                 ));
             }
@@ -97,7 +97,7 @@ fn materialize_event_value(
         } => {
             let data = read_overflow_chain(mvcc, dirty, *root_id)?;
             if (data.len() as u64) != *data_len {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Overflow data length mismatch".to_string(),
                 ));
             }
@@ -147,7 +147,7 @@ pub fn event_tree_append(
                 .last()
                 .expect("Internal node should have some children");
         } else {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Expected EventInternal node".to_string(),
             ));
         }
@@ -205,14 +205,14 @@ pub fn event_tree_append(
                         }
                         popped = Some((last_key, last_value));
                     } else {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Expected EventLeaf node".to_string(),
                         ));
                     }
                 }
             }
             _ => {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected EventLeaf node at event tree root".to_string(),
                 ));
             }
@@ -295,7 +295,7 @@ pub fn event_tree_append(
                 println!("Nothing to replace in {dirty_page_id:?}")
             }
         } else {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Expected EventInternal node".to_string(),
             ));
         }
@@ -312,7 +312,7 @@ pub fn event_tree_append(
                     );
                 }
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected EventInternal node".to_string(),
                 ));
             }
@@ -328,7 +328,7 @@ pub fn event_tree_append(
                 // Split the internal node
                 // Ensure we have at least 3 keys and 4 child IDs before splitting
                 if dirty_internal_node.keys.len() < 3 || dirty_internal_node.child_ids.len() < 4 {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Cannot split internal node with too few keys/children".to_string(),
                     ));
                 }
@@ -367,7 +367,7 @@ pub fn event_tree_append(
 
                 split_info = Some((promoted_key, new_internal_page_id));
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected EventInternal node".to_string(),
                 ));
             }
@@ -384,7 +384,7 @@ pub fn event_tree_append(
                 println!("Replaced root {old_id:?} with {new_id:?}");
             }
         } else {
-            return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
+            return Err(DcbError::RootIDMismatch(old_id.0, new_id.0));
         }
     }
 
@@ -433,7 +433,7 @@ pub fn event_tree_lookup(
                     Err(i) => i,
                 };
                 if idx >= internal.child_ids.len() {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Child index out of bounds in event tree".to_string(),
                     ));
                 }
@@ -445,13 +445,13 @@ pub fn event_tree_lookup(
                         let rec = materialize_event_value(mvcc, dirty, &leaf.values[i])?;
                         Ok(rec)
                     }
-                    Err(_) => Err(DdbError::DatabaseCorrupted(format!(
+                    Err(_) => Err(DcbError::DatabaseCorrupted(format!(
                         "Event at position {position:?} not found",
                     ))),
                 };
             }
             _ => {
-                return Err(DdbError::DatabaseCorrupted(format!(
+                return Err(DcbError::DatabaseCorrupted(format!(
                     "Expected EventInternal or EventLeaf node in event tree, got {}",
                     page.node.type_name()
                 )));
@@ -649,7 +649,7 @@ impl<'a> EventIterator<'a> {
                         }
                     }
                     _ => {
-                        return Err(DdbError::DatabaseCorrupted(format!(
+                        return Err(DcbError::DatabaseCorrupted(format!(
                             "Expected EventInternal or EventLeaf node in event tree, got {}",
                             page_ref.node.type_name()
                         )));

--- a/umadb-core/src/events_tree_nodes.rs
+++ b/umadb-core/src/events_tree_nodes.rs
@@ -2,8 +2,8 @@ use crate::common::PageID;
 use crate::common::Position;
 use bitflags::bitflags;
 use byteorder::{ByteOrder, LittleEndian};
-use umadb_dcb::DCBError;
-use umadb_dcb::DCBResult;
+use umadb_dcb::DdbError;
+use umadb_dcb::DcbResult;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -216,10 +216,10 @@ impl EventLeafNode {
         i
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         // Check if the slice has at least 2 bytes for keys_len
         if slice.len() < 2 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -231,7 +231,7 @@ impl EventLeafNode {
         // Calculate the minimum expected size for the keys
         let min_expected_size = 2 + (keys_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 min_expected_size,
                 slice.len()
@@ -253,33 +253,33 @@ impl EventLeafNode {
         for _ in 0..keys_len {
             // Read discriminator (1 byte)
             if offset + 1 > slice.len() {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "Unexpected end of data while reading value kind".to_string(),
                 ));
             }
 
             let flags = EventValueFlags::from_bits(slice[offset]).ok_or(
-                DCBError::DeserializationError("unknown flag bits set".to_string()),
+                DdbError::DeserializationError("unknown flag bits set".to_string()),
             )?;
             offset += 1;
 
             // Extract event_type length (2 bytes)
             if offset + 2 > slice.len() {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "Unexpected end of data while reading event_type length".to_string(),
                 ));
             }
             let event_type_len = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
             offset += 2;
             if offset + event_type_len > slice.len() {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "Unexpected end of data while reading event_type".to_string(),
                 ));
             }
             let event_type = match std::str::from_utf8(&slice[offset..offset + event_type_len]) {
                 Ok(s) => s.to_string(),
                 Err(_) => {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "Invalid UTF-8 sequence in event_type".to_string(),
                     ));
                 }
@@ -292,14 +292,14 @@ impl EventLeafNode {
             if !overflow {
                 // Inline: data_len u16 + data bytes
                 if offset + 2 > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "Unexpected end of data while reading data length".to_string(),
                     ));
                 }
                 let data_len = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
                 offset += 2;
                 if offset + data_len > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "Unexpected end of data while reading data".to_string(),
                     ));
                 }
@@ -308,7 +308,7 @@ impl EventLeafNode {
 
                 // num tags
                 if offset + 2 > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "Unexpected end of data while reading number of tags".to_string(),
                     ));
                 }
@@ -317,21 +317,21 @@ impl EventLeafNode {
                 let mut tags = Vec::with_capacity(num_tags);
                 for _ in 0..num_tags {
                     if offset + 2 > slice.len() {
-                        return Err(DCBError::DeserializationError(
+                        return Err(DdbError::DeserializationError(
                             "Unexpected end of data while reading tag length".to_string(),
                         ));
                     }
                     let tag_len = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
                     offset += 2;
                     if offset + tag_len > slice.len() {
-                        return Err(DCBError::DeserializationError(
+                        return Err(DdbError::DeserializationError(
                             "Unexpected end of data while reading tag".to_string(),
                         ));
                     }
                     let tag = match std::str::from_utf8(&slice[offset..offset + tag_len]) {
                         Ok(s) => s.to_string(),
                         Err(_) => {
-                            return Err(DCBError::DeserializationError(
+                            return Err(DdbError::DeserializationError(
                                 "Invalid UTF-8 sequence in tag".to_string(),
                             ));
                         }
@@ -343,7 +343,7 @@ impl EventLeafNode {
                 let uuid = {
                     if has_uuid {
                         if offset + 16 > slice.len() {
-                            return Err(DCBError::DeserializationError(
+                            return Err(DdbError::DeserializationError(
                                 "Unexpected end of data while reading UUID".to_string(),
                             ));
                         }
@@ -354,7 +354,7 @@ impl EventLeafNode {
                                 Some(uuid)
                             }
                             Err(err) => {
-                                return Err(DCBError::DeserializationError(
+                                return Err(DdbError::DeserializationError(
                                     format!("Invalid UUID sequence: {err} ").to_string(),
                                 ));
                             }
@@ -373,7 +373,7 @@ impl EventLeafNode {
             } else {
                 // Overflow: data_len u64 + tags + root_id
                 if offset + 8 > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "Unexpected end of data while reading overflow data_len".to_string(),
                     ));
                 }
@@ -381,7 +381,7 @@ impl EventLeafNode {
                 offset += 8;
 
                 if offset + 2 > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "Unexpected end of data while reading number of tags".to_string(),
                     ));
                 }
@@ -390,21 +390,21 @@ impl EventLeafNode {
                 let mut tags = Vec::with_capacity(num_tags);
                 for _ in 0..num_tags {
                     if offset + 2 > slice.len() {
-                        return Err(DCBError::DeserializationError(
+                        return Err(DdbError::DeserializationError(
                             "Unexpected end of data while reading tag length".to_string(),
                         ));
                     }
                     let tag_len = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
                     offset += 2;
                     if offset + tag_len > slice.len() {
-                        return Err(DCBError::DeserializationError(
+                        return Err(DdbError::DeserializationError(
                             "Unexpected end of data while reading tag".to_string(),
                         ));
                     }
                     let tag = match std::str::from_utf8(&slice[offset..offset + tag_len]) {
                         Ok(s) => s.to_string(),
                         Err(_) => {
-                            return Err(DCBError::DeserializationError(
+                            return Err(DdbError::DeserializationError(
                                 "Invalid UTF-8 sequence in tag".to_string(),
                             ));
                         }
@@ -413,7 +413,7 @@ impl EventLeafNode {
                     tags.push(tag);
                 }
                 if offset + 8 > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "Unexpected end of data while reading overflow root_id".to_string(),
                     ));
                 }
@@ -423,7 +423,7 @@ impl EventLeafNode {
                 let uuid = {
                     if has_uuid {
                         if offset + 16 > slice.len() {
-                            return Err(DCBError::DeserializationError(
+                            return Err(DdbError::DeserializationError(
                                 "Unexpected end of data while reading UUID".to_string(),
                             ));
                         }
@@ -434,7 +434,7 @@ impl EventLeafNode {
                                 Some(uuid)
                             }
                             Err(err) => {
-                                return Err(DCBError::DeserializationError(
+                                return Err(DdbError::DeserializationError(
                                     format!("Invalid UUID sequence: {err} ").to_string(),
                                 ));
                             }
@@ -457,7 +457,7 @@ impl EventLeafNode {
         Ok(EventLeafNode { keys, values })
     }
 
-    pub fn pop_last_key_and_value(&mut self) -> DCBResult<(Position, EventValue)> {
+    pub fn pop_last_key_and_value(&mut self) -> DcbResult<(Position, EventValue)> {
         let last_key = self
             .keys
             .pop()
@@ -489,9 +489,9 @@ impl EventOverflowNode {
         size
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 8 {
-            return Err(DCBError::DeserializationError(
+            return Err(DdbError::DeserializationError(
                 "Overflow node too small".to_string(),
             ));
         }
@@ -521,7 +521,7 @@ impl EventInternalNode {
         total_size
     }
 
-    pub fn serialize_into(&self, buf: &mut [u8]) -> DCBResult<usize> {
+    pub fn serialize_into(&self, buf: &mut [u8]) -> DcbResult<usize> {
         let mut i = 0usize;
         let klen = self.keys.len() as u16;
         buf[i..i + 2].copy_from_slice(&klen.to_le_bytes());
@@ -537,10 +537,10 @@ impl EventInternalNode {
         Ok(i)
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         // Check if the slice has at least 2 bytes for keys_len
         if slice.len() < 2 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -552,7 +552,7 @@ impl EventInternalNode {
         // Calculate the minimum expected size for the keys
         let min_expected_size = 2 + (keys_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 min_expected_size,
                 slice.len()
@@ -576,7 +576,7 @@ impl EventInternalNode {
         // Calculate the minimum expected size for the child_ids
         let min_expected_size = offset + (child_ids_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for child_ids, got {}",
                 min_expected_size,
                 slice.len()
@@ -593,13 +593,13 @@ impl EventInternalNode {
 
         Ok(EventInternalNode { keys, child_ids })
     }
-    pub fn replace_last_child_id(&mut self, old_id: PageID, new_id: PageID) -> DCBResult<()> {
+    pub fn replace_last_child_id(&mut self, old_id: PageID, new_id: PageID) -> DcbResult<()> {
         // Replace the last child ID.
         let last_idx = self.child_ids.len() - 1;
         if self.child_ids[last_idx] == old_id {
             self.child_ids[last_idx] = new_id;
         } else {
-            return Err(DCBError::DatabaseCorrupted("Child ID mismatch".to_string()));
+            return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
         }
         Ok(())
     }
@@ -607,12 +607,12 @@ impl EventInternalNode {
         &mut self,
         promoted_key: Position,
         promoted_page_id: PageID,
-    ) -> DCBResult<()> {
+    ) -> DcbResult<()> {
         self.keys.push(promoted_key);
         self.child_ids.push(promoted_page_id);
         Ok(())
     }
-    pub fn split_off(&mut self) -> DCBResult<(Position, Vec<Position>, Vec<PageID>)> {
+    pub fn split_off(&mut self) -> DcbResult<(Position, Vec<Position>, Vec<PageID>)> {
         let middle_idx = self.keys.len() - 2;
         let promoted_key = self.keys.remove(middle_idx);
         let new_keys = self.keys.split_off(middle_idx);

--- a/umadb-core/src/events_tree_nodes.rs
+++ b/umadb-core/src/events_tree_nodes.rs
@@ -2,7 +2,7 @@ use crate::common::PageID;
 use crate::common::Position;
 use bitflags::bitflags;
 use byteorder::{ByteOrder, LittleEndian};
-use umadb_dcb::DdbError;
+use umadb_dcb::DcbError;
 use umadb_dcb::DcbResult;
 use uuid::Uuid;
 
@@ -219,7 +219,7 @@ impl EventLeafNode {
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         // Check if the slice has at least 2 bytes for keys_len
         if slice.len() < 2 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -231,7 +231,7 @@ impl EventLeafNode {
         // Calculate the minimum expected size for the keys
         let min_expected_size = 2 + (keys_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 min_expected_size,
                 slice.len()
@@ -253,33 +253,33 @@ impl EventLeafNode {
         for _ in 0..keys_len {
             // Read discriminator (1 byte)
             if offset + 1 > slice.len() {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "Unexpected end of data while reading value kind".to_string(),
                 ));
             }
 
             let flags = EventValueFlags::from_bits(slice[offset]).ok_or(
-                DdbError::DeserializationError("unknown flag bits set".to_string()),
+                DcbError::DeserializationError("unknown flag bits set".to_string()),
             )?;
             offset += 1;
 
             // Extract event_type length (2 bytes)
             if offset + 2 > slice.len() {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "Unexpected end of data while reading event_type length".to_string(),
                 ));
             }
             let event_type_len = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
             offset += 2;
             if offset + event_type_len > slice.len() {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "Unexpected end of data while reading event_type".to_string(),
                 ));
             }
             let event_type = match std::str::from_utf8(&slice[offset..offset + event_type_len]) {
                 Ok(s) => s.to_string(),
                 Err(_) => {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "Invalid UTF-8 sequence in event_type".to_string(),
                     ));
                 }
@@ -292,14 +292,14 @@ impl EventLeafNode {
             if !overflow {
                 // Inline: data_len u16 + data bytes
                 if offset + 2 > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "Unexpected end of data while reading data length".to_string(),
                     ));
                 }
                 let data_len = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
                 offset += 2;
                 if offset + data_len > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "Unexpected end of data while reading data".to_string(),
                     ));
                 }
@@ -308,7 +308,7 @@ impl EventLeafNode {
 
                 // num tags
                 if offset + 2 > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "Unexpected end of data while reading number of tags".to_string(),
                     ));
                 }
@@ -317,21 +317,21 @@ impl EventLeafNode {
                 let mut tags = Vec::with_capacity(num_tags);
                 for _ in 0..num_tags {
                     if offset + 2 > slice.len() {
-                        return Err(DdbError::DeserializationError(
+                        return Err(DcbError::DeserializationError(
                             "Unexpected end of data while reading tag length".to_string(),
                         ));
                     }
                     let tag_len = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
                     offset += 2;
                     if offset + tag_len > slice.len() {
-                        return Err(DdbError::DeserializationError(
+                        return Err(DcbError::DeserializationError(
                             "Unexpected end of data while reading tag".to_string(),
                         ));
                     }
                     let tag = match std::str::from_utf8(&slice[offset..offset + tag_len]) {
                         Ok(s) => s.to_string(),
                         Err(_) => {
-                            return Err(DdbError::DeserializationError(
+                            return Err(DcbError::DeserializationError(
                                 "Invalid UTF-8 sequence in tag".to_string(),
                             ));
                         }
@@ -343,7 +343,7 @@ impl EventLeafNode {
                 let uuid = {
                     if has_uuid {
                         if offset + 16 > slice.len() {
-                            return Err(DdbError::DeserializationError(
+                            return Err(DcbError::DeserializationError(
                                 "Unexpected end of data while reading UUID".to_string(),
                             ));
                         }
@@ -354,7 +354,7 @@ impl EventLeafNode {
                                 Some(uuid)
                             }
                             Err(err) => {
-                                return Err(DdbError::DeserializationError(
+                                return Err(DcbError::DeserializationError(
                                     format!("Invalid UUID sequence: {err} ").to_string(),
                                 ));
                             }
@@ -373,7 +373,7 @@ impl EventLeafNode {
             } else {
                 // Overflow: data_len u64 + tags + root_id
                 if offset + 8 > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "Unexpected end of data while reading overflow data_len".to_string(),
                     ));
                 }
@@ -381,7 +381,7 @@ impl EventLeafNode {
                 offset += 8;
 
                 if offset + 2 > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "Unexpected end of data while reading number of tags".to_string(),
                     ));
                 }
@@ -390,21 +390,21 @@ impl EventLeafNode {
                 let mut tags = Vec::with_capacity(num_tags);
                 for _ in 0..num_tags {
                     if offset + 2 > slice.len() {
-                        return Err(DdbError::DeserializationError(
+                        return Err(DcbError::DeserializationError(
                             "Unexpected end of data while reading tag length".to_string(),
                         ));
                     }
                     let tag_len = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
                     offset += 2;
                     if offset + tag_len > slice.len() {
-                        return Err(DdbError::DeserializationError(
+                        return Err(DcbError::DeserializationError(
                             "Unexpected end of data while reading tag".to_string(),
                         ));
                     }
                     let tag = match std::str::from_utf8(&slice[offset..offset + tag_len]) {
                         Ok(s) => s.to_string(),
                         Err(_) => {
-                            return Err(DdbError::DeserializationError(
+                            return Err(DcbError::DeserializationError(
                                 "Invalid UTF-8 sequence in tag".to_string(),
                             ));
                         }
@@ -413,7 +413,7 @@ impl EventLeafNode {
                     tags.push(tag);
                 }
                 if offset + 8 > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "Unexpected end of data while reading overflow root_id".to_string(),
                     ));
                 }
@@ -423,7 +423,7 @@ impl EventLeafNode {
                 let uuid = {
                     if has_uuid {
                         if offset + 16 > slice.len() {
-                            return Err(DdbError::DeserializationError(
+                            return Err(DcbError::DeserializationError(
                                 "Unexpected end of data while reading UUID".to_string(),
                             ));
                         }
@@ -434,7 +434,7 @@ impl EventLeafNode {
                                 Some(uuid)
                             }
                             Err(err) => {
-                                return Err(DdbError::DeserializationError(
+                                return Err(DcbError::DeserializationError(
                                     format!("Invalid UUID sequence: {err} ").to_string(),
                                 ));
                             }
@@ -491,7 +491,7 @@ impl EventOverflowNode {
 
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 8 {
-            return Err(DdbError::DeserializationError(
+            return Err(DcbError::DeserializationError(
                 "Overflow node too small".to_string(),
             ));
         }
@@ -540,7 +540,7 @@ impl EventInternalNode {
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         // Check if the slice has at least 2 bytes for keys_len
         if slice.len() < 2 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -552,7 +552,7 @@ impl EventInternalNode {
         // Calculate the minimum expected size for the keys
         let min_expected_size = 2 + (keys_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 min_expected_size,
                 slice.len()
@@ -576,7 +576,7 @@ impl EventInternalNode {
         // Calculate the minimum expected size for the child_ids
         let min_expected_size = offset + (child_ids_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for child_ids, got {}",
                 min_expected_size,
                 slice.len()
@@ -599,7 +599,7 @@ impl EventInternalNode {
         if self.child_ids[last_idx] == old_id {
             self.child_ids[last_idx] = new_id;
         } else {
-            return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
+            return Err(DcbError::DatabaseCorrupted("Child ID mismatch".to_string()));
         }
         Ok(())
     }

--- a/umadb-core/src/free_lists_tree_nodes.rs
+++ b/umadb-core/src/free_lists_tree_nodes.rs
@@ -1,6 +1,6 @@
 use crate::common::{PageID, Tsn};
 use byteorder::{ByteOrder, LittleEndian};
-use umadb_dcb::{DCBError, DCBResult};
+use umadb_dcb::{DdbError, DcbResult};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FreeListLeafNode {
@@ -71,10 +71,10 @@ impl FreeListLeafNode {
     ///
     /// # Returns
     /// * `Result<Self>` - The deserialized FreeListLeafNode or an error
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         // Check if the slice has at least 2 bytes for keys_len
         if slice.len() < 2 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -86,7 +86,7 @@ impl FreeListLeafNode {
         // Calculate the minimum expected size for the keys
         let min_expected_size = 2 + (keys_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 min_expected_size,
                 slice.len()
@@ -107,7 +107,7 @@ impl FreeListLeafNode {
 
         for _ in 0..keys_len {
             if offset + 2 > slice.len() {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "Unexpected end of data while reading page_ids length".to_string(),
                 ));
             }
@@ -117,7 +117,7 @@ impl FreeListLeafNode {
             offset += 2;
 
             if offset + (page_ids_len * 8) > slice.len() {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "Unexpected end of data while reading page_ids".to_string(),
                 ));
             }
@@ -132,7 +132,7 @@ impl FreeListLeafNode {
             offset += page_ids_len * 8;
 
             if offset + 8 > slice.len() {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "Unexpected end of data while reading root_id".to_string(),
                 ));
             }
@@ -173,7 +173,7 @@ impl FreeListLeafNode {
         self.values[idx].page_ids.push(page_id);
     }
 
-    pub fn pop_last_key_and_value(&mut self) -> DCBResult<(Tsn, FreeListLeafValue)> {
+    pub fn pop_last_key_and_value(&mut self) -> DcbResult<(Tsn, FreeListLeafValue)> {
         let last_key = self
             .keys
             .pop()
@@ -239,10 +239,10 @@ impl FreeListInternalNode {
     ///
     /// # Returns
     /// * `Result<Self>` - The deserialized FreeListInternalNode or an error
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         // Check if the slice has at least 2 bytes for keys_len
         if slice.len() < 2 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -254,7 +254,7 @@ impl FreeListInternalNode {
         // Calculate the minimum expected size for the keys
         let min_expected_size = 2 + (keys_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 min_expected_size,
                 slice.len()
@@ -272,7 +272,7 @@ impl FreeListInternalNode {
         // Extract the length of child_ids (2 bytes)
         let offset = 2 + (keys_len * 8);
         if offset + 2 > slice.len() {
-            return Err(DCBError::DeserializationError(
+            return Err(DdbError::DeserializationError(
                 "Unexpected end of data while reading child_ids length".to_string(),
             ));
         }
@@ -282,7 +282,7 @@ impl FreeListInternalNode {
         // Calculate the minimum expected size for the child_ids
         let min_expected_size = offset + 2 + (child_ids_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for child_ids, got {}",
                 min_expected_size,
                 slice.len()
@@ -300,13 +300,13 @@ impl FreeListInternalNode {
         Ok(FreeListInternalNode { keys, child_ids })
     }
 
-    pub fn replace_last_child_id(&mut self, old_id: PageID, new_id: PageID) -> DCBResult<()> {
+    pub fn replace_last_child_id(&mut self, old_id: PageID, new_id: PageID) -> DcbResult<()> {
         // Replace the last child ID.
         let last_idx = self.child_ids.len() - 1;
         if self.child_ids[last_idx] == old_id {
             self.child_ids[last_idx] = new_id;
         } else {
-            return Err(DCBError::DatabaseCorrupted("Child ID mismatch".to_string()));
+            return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
         }
         Ok(())
     }
@@ -315,13 +315,13 @@ impl FreeListInternalNode {
         &mut self,
         promoted_key: Tsn,
         promoted_page_id: PageID,
-    ) -> DCBResult<()> {
+    ) -> DcbResult<()> {
         self.keys.push(promoted_key);
         self.child_ids.push(promoted_page_id);
         Ok(())
     }
 
-    pub(crate) fn split_off(&mut self) -> DCBResult<(Tsn, Vec<Tsn>, Vec<PageID>)> {
+    pub(crate) fn split_off(&mut self) -> DcbResult<(Tsn, Vec<Tsn>, Vec<PageID>)> {
         let middle_idx = self.keys.len() - 2;
         let promoted_key = self.keys.remove(middle_idx);
         let new_keys = self.keys.split_off(middle_idx);
@@ -354,9 +354,9 @@ impl FreeListTsnLeafNode {
         i
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -364,7 +364,7 @@ impl FreeListTsnLeafNode {
         let plen = LittleEndian::read_u16(&slice[0..2]) as usize;
         let need = 2 + plen * 8;
         if slice.len() < need {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes, got {}",
                 need,
                 slice.len()
@@ -418,15 +418,15 @@ impl FreeListTsnInternalNode {
         i
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DCBError::DeserializationError(
+            return Err(DdbError::DeserializationError(
                 "Expected at least 2 bytes".to_string(),
             ));
         }
         let klen = LittleEndian::read_u16(&slice[0..2]) as usize;
         if slice.len() < 2 + klen * 8 + 2 {
-            return Err(DCBError::DeserializationError("Data too short".to_string()));
+            return Err(DdbError::DeserializationError("Data too short".to_string()));
         }
         let mut keys = Vec::with_capacity(klen);
         let mut offset = 2;
@@ -438,7 +438,7 @@ impl FreeListTsnInternalNode {
         let clen = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
         offset += 2;
         if slice.len() < offset + clen * 8 {
-            return Err(DCBError::DeserializationError("Data too short".to_string()));
+            return Err(DdbError::DeserializationError("Data too short".to_string()));
         }
         let mut child_ids = Vec::with_capacity(clen);
         for _ in 0..clen {

--- a/umadb-core/src/free_lists_tree_nodes.rs
+++ b/umadb-core/src/free_lists_tree_nodes.rs
@@ -1,6 +1,6 @@
 use crate::common::{PageID, Tsn};
 use byteorder::{ByteOrder, LittleEndian};
-use umadb_dcb::{DdbError, DcbResult};
+use umadb_dcb::{DcbError, DcbResult};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FreeListLeafNode {
@@ -74,7 +74,7 @@ impl FreeListLeafNode {
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         // Check if the slice has at least 2 bytes for keys_len
         if slice.len() < 2 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -86,7 +86,7 @@ impl FreeListLeafNode {
         // Calculate the minimum expected size for the keys
         let min_expected_size = 2 + (keys_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 min_expected_size,
                 slice.len()
@@ -107,7 +107,7 @@ impl FreeListLeafNode {
 
         for _ in 0..keys_len {
             if offset + 2 > slice.len() {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "Unexpected end of data while reading page_ids length".to_string(),
                 ));
             }
@@ -117,7 +117,7 @@ impl FreeListLeafNode {
             offset += 2;
 
             if offset + (page_ids_len * 8) > slice.len() {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "Unexpected end of data while reading page_ids".to_string(),
                 ));
             }
@@ -132,7 +132,7 @@ impl FreeListLeafNode {
             offset += page_ids_len * 8;
 
             if offset + 8 > slice.len() {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "Unexpected end of data while reading root_id".to_string(),
                 ));
             }
@@ -242,7 +242,7 @@ impl FreeListInternalNode {
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         // Check if the slice has at least 2 bytes for keys_len
         if slice.len() < 2 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -254,7 +254,7 @@ impl FreeListInternalNode {
         // Calculate the minimum expected size for the keys
         let min_expected_size = 2 + (keys_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 min_expected_size,
                 slice.len()
@@ -272,7 +272,7 @@ impl FreeListInternalNode {
         // Extract the length of child_ids (2 bytes)
         let offset = 2 + (keys_len * 8);
         if offset + 2 > slice.len() {
-            return Err(DdbError::DeserializationError(
+            return Err(DcbError::DeserializationError(
                 "Unexpected end of data while reading child_ids length".to_string(),
             ));
         }
@@ -282,7 +282,7 @@ impl FreeListInternalNode {
         // Calculate the minimum expected size for the child_ids
         let min_expected_size = offset + 2 + (child_ids_len * 8);
         if slice.len() < min_expected_size {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for child_ids, got {}",
                 min_expected_size,
                 slice.len()
@@ -306,7 +306,7 @@ impl FreeListInternalNode {
         if self.child_ids[last_idx] == old_id {
             self.child_ids[last_idx] = new_id;
         } else {
-            return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
+            return Err(DcbError::DatabaseCorrupted("Child ID mismatch".to_string()));
         }
         Ok(())
     }
@@ -356,7 +356,7 @@ impl FreeListTsnLeafNode {
 
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -364,7 +364,7 @@ impl FreeListTsnLeafNode {
         let plen = LittleEndian::read_u16(&slice[0..2]) as usize;
         let need = 2 + plen * 8;
         if slice.len() < need {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes, got {}",
                 need,
                 slice.len()
@@ -420,13 +420,13 @@ impl FreeListTsnInternalNode {
 
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DdbError::DeserializationError(
+            return Err(DcbError::DeserializationError(
                 "Expected at least 2 bytes".to_string(),
             ));
         }
         let klen = LittleEndian::read_u16(&slice[0..2]) as usize;
         if slice.len() < 2 + klen * 8 + 2 {
-            return Err(DdbError::DeserializationError("Data too short".to_string()));
+            return Err(DcbError::DeserializationError("Data too short".to_string()));
         }
         let mut keys = Vec::with_capacity(klen);
         let mut offset = 2;
@@ -438,7 +438,7 @@ impl FreeListTsnInternalNode {
         let clen = LittleEndian::read_u16(&slice[offset..offset + 2]) as usize;
         offset += 2;
         if slice.len() < offset + clen * 8 {
-            return Err(DdbError::DeserializationError("Data too short".to_string()));
+            return Err(DcbError::DeserializationError("Data too short".to_string()));
         }
         let mut child_ids = Vec::with_capacity(clen);
         for _ in 0..clen {

--- a/umadb-core/src/header_node.rs
+++ b/umadb-core/src/header_node.rs
@@ -2,7 +2,7 @@ use crate::common::Position;
 use crate::common::{PageID, Tsn};
 use bitflags::bitflags;
 use byteorder::{ByteOrder, LittleEndian};
-use umadb_dcb::{DCBError, DCBResult};
+use umadb_dcb::{DdbError, DcbResult};
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -108,9 +108,9 @@ impl HeaderNode {
     ///
     /// # Returns
     /// * `Result<Self>` - The deserialized HeaderNode or an error
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 48 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 48 bytes, got {}",
                 slice.len()
             )));
@@ -129,7 +129,7 @@ impl HeaderNode {
         };
         let flags = if slice.len() >= 54 {
             HeaderFlags::from_bits(LittleEndian::read_u16(&slice[52..54])).ok_or(
-                DCBError::DeserializationError("unknown flag bits set".to_string()),
+                DdbError::DeserializationError("unknown flag bits set".to_string()),
             )?
         } else {
             HeaderFlags::empty()
@@ -140,7 +140,7 @@ impl HeaderNode {
         if flags.contains(HeaderFlags::HAS_TRACKING_ROOT_ID) {
             required_len += 8;
             if slice.len() < required_len {
-                return Err(DCBError::DeserializationError(format!(
+                return Err(DdbError::DeserializationError(format!(
                     "Expected at least {required_len} bytes, got {}",
                     slice.len()
                 )));

--- a/umadb-core/src/header_node.rs
+++ b/umadb-core/src/header_node.rs
@@ -2,7 +2,7 @@ use crate::common::Position;
 use crate::common::{PageID, Tsn};
 use bitflags::bitflags;
 use byteorder::{ByteOrder, LittleEndian};
-use umadb_dcb::{DdbError, DcbResult};
+use umadb_dcb::{DcbError, DcbResult};
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -110,7 +110,7 @@ impl HeaderNode {
     /// * `Result<Self>` - The deserialized HeaderNode or an error
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 48 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 48 bytes, got {}",
                 slice.len()
             )));
@@ -129,7 +129,7 @@ impl HeaderNode {
         };
         let flags = if slice.len() >= 54 {
             HeaderFlags::from_bits(LittleEndian::read_u16(&slice[52..54])).ok_or(
-                DdbError::DeserializationError("unknown flag bits set".to_string()),
+                DcbError::DeserializationError("unknown flag bits set".to_string()),
             )?
         } else {
             HeaderFlags::empty()
@@ -140,7 +140,7 @@ impl HeaderNode {
         if flags.contains(HeaderFlags::HAS_TRACKING_ROOT_ID) {
             required_len += 8;
             if slice.len() < required_len {
-                return Err(DdbError::DeserializationError(format!(
+                return Err(DcbError::DeserializationError(format!(
                     "Expected at least {required_len} bytes, got {}",
                     slice.len()
                 )));

--- a/umadb-core/src/mvcc.rs
+++ b/umadb-core/src/mvcc.rs
@@ -19,8 +19,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
-use umadb_dcb::DdbError::InternalError;
-use umadb_dcb::{DcbQuery, DcbResult, DdbError};
+use umadb_dcb::DcbError::InternalError;
+use umadb_dcb::{DcbQuery, DcbResult, DcbError};
 
 const GET_LATEST_HEADER_RETRIES: usize = 5;
 const GET_LATEST_HEADER_DELAY: Duration = Duration::from_millis(10);
@@ -311,7 +311,7 @@ impl Mvcc {
                         sleep(GET_LATEST_HEADER_DELAY);
                         continue;
                     } else {
-                        return Err(DdbError::DatabaseCorrupted(format!(
+                        return Err(DcbError::DatabaseCorrupted(format!(
                             "Both header pages appear corrupted after {} attempts: ({:?}) and ({:?})",
                             GET_LATEST_HEADER_RETRIES, e0, e1
                         )));
@@ -320,7 +320,7 @@ impl Mvcc {
             }
         }
         // Unreachable due to returns in match and final error, but keep to satisfy type checker
-        Err(DdbError::DatabaseCorrupted(
+        Err(DcbError::DatabaseCorrupted(
             "Unable to read a valid header".to_string(),
         ))
     }
@@ -329,7 +329,7 @@ impl Mvcc {
         let page = self.read_page(page_id)?;
         match page.node {
             Node::Header(node) => Ok(node),
-            _ => Err(DdbError::DatabaseCorrupted(
+            _ => Err(DcbError::DatabaseCorrupted(
                 "Invalid header node type".to_string(),
             )),
         }
@@ -661,7 +661,7 @@ impl Writer {
         if let Some(page) = self.dirty.get_mut(&page_id) {
             Ok(page)
         } else {
-            Err(DdbError::DirtyPageNotFound(page_id.0))
+            Err(DcbError::DirtyPageNotFound(page_id.0))
         }
     }
 
@@ -671,10 +671,10 @@ impl Writer {
 
     pub fn insert_dirty(&mut self, page: Page) -> DcbResult<()> {
         if self.freed_page_ids.contains(&page.page_id) {
-            return Err(DdbError::PageAlreadyFreed(page.page_id.0));
+            return Err(DcbError::PageAlreadyFreed(page.page_id.0));
         }
         if self.dirty.contains_key(&page.page_id) {
-            return Err(DdbError::PageAlreadyDirty(page.page_id.0));
+            return Err(DcbError::PageAlreadyDirty(page.page_id.0));
         }
         self.dirty.insert(page.page_id, page);
         Ok(())
@@ -717,7 +717,7 @@ impl Writer {
                 println!("{page_id:?} is already dirty");
             }
         } else {
-            return Err(DdbError::PageAlreadyFreed(page_id.0));
+            return Err(DcbError::PageAlreadyFreed(page_id.0));
         }
         Ok(dirty_page_id)
     }
@@ -770,7 +770,7 @@ impl Writer {
                 match self.get_page_ref(mvcc, page_id) {
                     Ok(p) => p.node.clone(),
                     Err(e) => {
-                        return Err(DdbError::DatabaseCorrupted(format!(
+                        return Err(DcbError::DatabaseCorrupted(format!(
                             "Free list page {:?} load error: {:?}",
                             page_id, e
                         )));
@@ -825,7 +825,7 @@ impl Writer {
                                     match self.get_page_ref(mvcc, sub_id) {
                                         Ok(p) => p.node.clone(),
                                         Err(e) => {
-                                            return Err(DdbError::DatabaseCorrupted(format!(
+                                            return Err(DcbError::DatabaseCorrupted(format!(
                                                 "TSN subtree page {:?} load error: {:?}",
                                                 sub_id, e
                                             )));
@@ -846,7 +846,7 @@ impl Writer {
                                         }
                                     }
                                     other => {
-                                        return Err(DdbError::DatabaseCorrupted(format!(
+                                        return Err(DcbError::DatabaseCorrupted(format!(
                                             "Invalid node type in TSN subtree: {}",
                                             other.type_name()
                                         )));
@@ -857,7 +857,7 @@ impl Writer {
                     }
                 }
                 _ => {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Invalid node type in free list tree".to_string(),
                     ));
                 }
@@ -895,7 +895,7 @@ impl Writer {
                 let len_keys = leaf_node.keys.len();
                 if len_keys == 0 {
                     if !leaf_node.would_fit_new_tsn_and_page_id(mvcc.max_node_size) {
-                        return Err(DdbError::InternalError("Page size too small".to_string()));
+                        return Err(DcbError::InternalError("Page size too small".to_string()));
                     }
                     plan = FreePageIDInsertStrategy::PushTsnOntoFreeListLeaf;
                 } else {
@@ -921,7 +921,7 @@ impl Writer {
                         }
                     } else {
                         // We assume freed page IDs are always inserted for the last TSN
-                        return Err(DdbError::InternalError(
+                        return Err(DcbError::InternalError(
                             "Insertion only supported for last TSN in leaf".to_string(),
                         ));
                     }
@@ -938,7 +938,7 @@ impl Writer {
                     .last()
                     .expect("FreeListInternal node should have a child");
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected FreeListInternal node".to_string(),
                 ));
             }
@@ -964,14 +964,14 @@ impl Writer {
                 // Read leaf immutably to find last_idx and current root_id
                 let leaf_snapshot = { self.get_page_ref(mvcc, dirty_leaf_page_id)? };
                 let Node::FreeListLeaf(leaf_ro) = &leaf_snapshot.node else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected FreeListLeaf node".to_string(),
                     ));
                 };
                 let last_idx = leaf_ro.keys.len() - 1;
                 let tsn_root_id = leaf_ro.values[last_idx].root_id;
                 if tsn_root_id == PageID(0) {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected TSN-subtree root_id to be set".to_string(),
                     ));
                 }
@@ -980,7 +980,7 @@ impl Writer {
                     // Now mutate the freelist leaf to update root_id
                     let dirty_leaf_page = self.get_mut_dirty(dirty_leaf_page_id)?;
                     let Node::FreeListLeaf(dirty_leaf_node2) = &mut dirty_leaf_page.node else {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Expected FreeListLeaf node".to_string(),
                         ));
                     };
@@ -991,7 +991,7 @@ impl Writer {
                 // Read leaf immutably to capture inline page_ids
                 let leaf_snapshot = { self.get_page_ref(mvcc, dirty_leaf_page_id)? };
                 let Node::FreeListLeaf(leaf_ro) = &leaf_snapshot.node else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected FreeListLeaf node".to_string(),
                     ));
                 };
@@ -1019,7 +1019,7 @@ impl Writer {
                     }
                 }
                 if initial_ids.is_empty() {
-                    return Err(DdbError::InternalError(
+                    return Err(DcbError::InternalError(
                         "Page size too small for TSN-subtree leaf with one PageID".to_string(),
                     ));
                 }
@@ -1035,7 +1035,7 @@ impl Writer {
                 // Now mutate the freelist leaf to clear inline and set root
                 let dirty_leaf_page = self.get_mut_dirty(dirty_leaf_page_id)?;
                 let Node::FreeListLeaf(dirty_leaf_node2) = &mut dirty_leaf_page.node else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected FreeListLeaf node".to_string(),
                     ));
                 };
@@ -1137,7 +1137,7 @@ impl Writer {
                 }
             }
         } else {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Expected FreeListLeaf node".to_string(),
             ));
         }
@@ -1168,7 +1168,7 @@ impl Writer {
                     println!("Nothing to replace in {dirty_page_id:?}")
                 }
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected FreeListInternal node".to_string(),
                 ));
             }
@@ -1185,7 +1185,7 @@ impl Writer {
                         );
                     }
                 } else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected FreeListInternal node".to_string(),
                     ));
                 }
@@ -1202,7 +1202,7 @@ impl Writer {
                     // Ensure we have at least 3 keys and 4 child IDs before splitting
                     if dirty_internal_node.keys.len() < 3 || dirty_internal_node.child_ids.len() < 4
                     {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Cannot split internal node with too few keys/children".to_string(),
                         ));
                     }
@@ -1244,7 +1244,7 @@ impl Writer {
 
                     split_info = Some((promoted_key, new_internal_page_id));
                 } else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected FreeListInternal node".to_string(),
                     ));
                 }
@@ -1261,7 +1261,7 @@ impl Writer {
                     println!("Replaced root {old_id:?} with {new_id:?}");
                 }
             } else {
-                return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
+                return Err(DcbError::RootIDMismatch(old_id.0, new_id.0));
             }
         }
 
@@ -1314,7 +1314,7 @@ impl Writer {
                     current_id = next_id;
                 }
                 other => {
-                    return Err(DdbError::DatabaseCorrupted(format!(
+                    return Err(DcbError::DatabaseCorrupted(format!(
                         "Unexpected node type in TSN-subtree during insert: {}",
                         other.type_name()
                     )));
@@ -1327,7 +1327,7 @@ impl Writer {
         {
             let leaf_page = self.get_mut_dirty(current_id)?;
             let Node::FreeListTsnLeaf(ref mut leaf) = leaf_page.node else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected TSN-subtree leaf".to_string(),
                 ));
             };
@@ -1365,7 +1365,7 @@ impl Writer {
                             let parent_page = self.get_mut_dirty(parent_id)?;
                             let Node::FreeListTsnInternal(ref mut parent_node) = parent_page.node
                             else {
-                                return Err(DdbError::DatabaseCorrupted(
+                                return Err(DcbError::DatabaseCorrupted(
                                     "Expected TSN-subtree internal".to_string(),
                                 ));
                             };
@@ -1395,13 +1395,13 @@ impl Writer {
                             let right_child_ids: Vec<PageID> =
                                 parent_node.child_ids[mid + 1..].to_vec();
                             if right_child_ids.len() != right_keys.len() + 1 {
-                                return Err(DdbError::DatabaseCorrupted(
+                                return Err(DcbError::DatabaseCorrupted(
                                     "TSN-subtree internal split produced invalid right arity"
                                         .to_string(),
                                 ));
                             }
                             if left_child_ids.len() != left_keys.len() + 1 {
-                                return Err(DdbError::DatabaseCorrupted(
+                                return Err(DcbError::DatabaseCorrupted(
                                     "TSN-subtree internal split produced invalid left arity"
                                         .to_string(),
                                 ));
@@ -1479,7 +1479,7 @@ impl Writer {
                 stack.push(current_page_id);
                 current_page_id = *internal_node.child_ids.first().unwrap();
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected FreeListInternal node".to_string(),
                 ));
             }
@@ -1496,12 +1496,12 @@ impl Writer {
         // Read the current leaf immutably to decide the path (inline vs TSN-subtree)
         let leaf_snapshot = { self.get_page_ref(mvcc, current_page_id)? };
         let Node::FreeListLeaf(leaf_node_ro) = &leaf_snapshot.node else {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Expected FreeListLeaf node".to_string(),
             ));
         };
         if leaf_node_ro.keys.is_empty() || leaf_node_ro.keys[0] != tsn {
-            return Err(DdbError::DatabaseCorrupted(format!(
+            return Err(DcbError::DatabaseCorrupted(format!(
                 "Expected TSN {} not found: {:?}",
                 tsn.0, leaf_node_ro
             )));
@@ -1529,7 +1529,7 @@ impl Writer {
                 {
                     leaf_value.page_ids.remove(pos);
                 } else {
-                    return Err(DdbError::DatabaseCorrupted(format!(
+                    return Err(DcbError::DatabaseCorrupted(format!(
                         "{used_page_id:?} not found in {tsn:?}"
                     )));
                 }
@@ -1554,7 +1554,7 @@ impl Writer {
                     println!("Leaf value not empty {tsn:?}: {leaf_value:?}");
                 }
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected FreeListLeaf node".to_string(),
                 ));
             }
@@ -1575,7 +1575,7 @@ impl Writer {
                     {
                         tsn_leaf_node.page_ids.remove(pos);
                     } else {
-                        return Err(DdbError::DatabaseCorrupted(format!(
+                        return Err(DcbError::DatabaseCorrupted(format!(
                             "{used_page_id:?} not found in TSN-subtree for {tsn:?}"
                         )));
                     }
@@ -1620,7 +1620,7 @@ impl Writer {
                                 current_id = next_id;
                             }
                             other => {
-                                return Err(DdbError::DatabaseCorrupted(format!(
+                                return Err(DcbError::DatabaseCorrupted(format!(
                                     "Unexpected node type in TSN-subtree during descent: {}",
                                     other.type_name()
                                 )));
@@ -1639,7 +1639,7 @@ impl Writer {
                                 {
                                     leaf_node.page_ids.remove(pos);
                                 } else {
-                                    return Err(DdbError::DatabaseCorrupted(format!(
+                                    return Err(DcbError::DatabaseCorrupted(format!(
                                         "{used_page_id:?} not found in TSN-subtree for {tsn:?}"
                                     )));
                                 }
@@ -1654,7 +1654,7 @@ impl Writer {
                                 }
                             }
                             other => {
-                                return Err(DdbError::DatabaseCorrupted(format!(
+                                return Err(DcbError::DatabaseCorrupted(format!(
                                     "Expected TSN-subtree leaf, got {}",
                                     other.type_name()
                                 )));
@@ -1678,7 +1678,7 @@ impl Writer {
                         let parent_page = self.get_mut_dirty(parent_dirty_id)?;
                         let Node::FreeListTsnInternal(ref mut parent_node) = parent_page.node
                         else {
-                            return Err(DdbError::DatabaseCorrupted(
+                            return Err(DcbError::DatabaseCorrupted(
                                 "Expected TSN-subtree internal node".to_string(),
                             ));
                         };
@@ -1741,7 +1741,7 @@ impl Writer {
                     }
                 }
                 _ => {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected TSN-subtree node".to_string(),
                     ));
                 }
@@ -1756,7 +1756,7 @@ impl Writer {
             if let Node::FreeListLeaf(dirty_leaf_node) = &mut dirty_leaf_page.node {
                 // Ensure expected TSN still at index 0
                 if dirty_leaf_node.keys.is_empty() || dirty_leaf_node.keys[0] != tsn {
-                    return Err(DdbError::DatabaseCorrupted(format!(
+                    return Err(DcbError::DatabaseCorrupted(format!(
                         "Expected TSN {} not found in dirty leaf: {:?}",
                         tsn.0, dirty_leaf_node
                     )));
@@ -1784,7 +1784,7 @@ impl Writer {
                     dirty_leaf_node.values[0].root_id = dirty_tsn_root_id;
                 }
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected FreeListLeaf node".to_string(),
                 ));
             }
@@ -1817,10 +1817,10 @@ impl Writer {
                             );
                         }
                     } else {
-                        return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
+                        return Err(DcbError::DatabaseCorrupted("Child ID mismatch".to_string()));
                     }
                 } else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected FreeListInternal node".to_string(),
                     ));
                 }
@@ -1833,10 +1833,10 @@ impl Writer {
                 if let Node::FreeListInternal(dirty_internal_node) = &mut dirty_internal_page.node {
                     // Remove the child ID and key
                     if dirty_internal_node.child_ids[0] != removed_page_id {
-                        return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
+                        return Err(DcbError::DatabaseCorrupted("Child ID mismatch".to_string()));
                     }
                     if dirty_internal_node.keys.is_empty() {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Empty internal node keys".to_string(),
                         ));
                     }
@@ -1867,7 +1867,7 @@ impl Writer {
                         }
                     }
                 } else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected FreeListInternal node".to_string(),
                     ));
                 }
@@ -1890,7 +1890,7 @@ impl Writer {
                     println!("Replaced root {old_id:?} with {new_id:?}");
                 }
             } else {
-                return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
+                return Err(DcbError::RootIDMismatch(old_id.0, new_id.0));
             }
         }
 
@@ -4293,7 +4293,7 @@ mod tests {
             // 4) Attempt to open again; expect an InternalError complaining about schema version
             match Mvcc::new(&db_path, page_size, verbose) {
                 Ok(_) => panic!("opening should have failed due to newer on-disk schema"),
-                Err(DdbError::InternalError(msg)) => {
+                Err(DcbError::InternalError(msg)) => {
                     assert!(
                         msg.contains("Software version is too old"),
                         "unexpected error message: {msg}"

--- a/umadb-core/src/mvcc.rs
+++ b/umadb-core/src/mvcc.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
 use umadb_dcb::DdbError::InternalError;
-use umadb_dcb::{DdbError, DcbQuery, DcbResult};
+use umadb_dcb::{DcbQuery, DcbResult, DdbError};
 
 const GET_LATEST_HEADER_RETRIES: usize = 5;
 const GET_LATEST_HEADER_DELAY: Duration = Duration::from_millis(10);
@@ -637,7 +637,7 @@ impl Writer {
     ///
     /// # Returns
     ///
-    /// A `DCBResult` containing a reference to the page if found, or an error if the page could not be found.
+    /// A `DcbResult` containing a reference to the page if found, or an error if the page could not be found.
     pub fn get_page_ref(&mut self, mvcc: &Mvcc, page_id: PageID) -> DcbResult<&Page> {
         // Check the dirty pages first
         if self.dirty.contains_key(&page_id) {

--- a/umadb-core/src/mvcc.rs
+++ b/umadb-core/src/mvcc.rs
@@ -19,8 +19,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
-use umadb_dcb::DCBError::InternalError;
-use umadb_dcb::{DCBError, DCBQuery, DCBResult};
+use umadb_dcb::DdbError::InternalError;
+use umadb_dcb::{DdbError, DcbQuery, DcbResult};
 
 const GET_LATEST_HEADER_RETRIES: usize = 5;
 const GET_LATEST_HEADER_DELAY: Duration = Duration::from_millis(10);
@@ -45,7 +45,7 @@ pub struct Mvcc {
 }
 
 impl Mvcc {
-    pub fn new(path: &Path, page_size: usize, verbose: bool) -> DCBResult<Self> {
+    pub fn new(path: &Path, page_size: usize, verbose: bool) -> DcbResult<Self> {
         let pager = Pager::new(path, page_size)?;
 
         let mvcc = Self {
@@ -229,7 +229,7 @@ impl Mvcc {
                         &empty_dirty,
                         header_latest.events_tree_root_id,
                         header_latest.tags_tree_root_id,
-                        DCBQuery { items: vec![] },
+                        DcbQuery { items: vec![] },
                         None,
                         true,
                         Some(1),
@@ -279,7 +279,7 @@ impl Mvcc {
         Ok(mvcc)
     }
 
-    pub fn get_latest_header(&self) -> DCBResult<(PageID, HeaderNode)> {
+    pub fn get_latest_header(&self) -> DcbResult<(PageID, HeaderNode)> {
         for attempt in 0..GET_LATEST_HEADER_RETRIES {
             let h0 = self.read_header(HEADER_PAGE_ID_0);
             let h1 = self.read_header(HEADER_PAGE_ID_1);
@@ -311,7 +311,7 @@ impl Mvcc {
                         sleep(GET_LATEST_HEADER_DELAY);
                         continue;
                     } else {
-                        return Err(DCBError::DatabaseCorrupted(format!(
+                        return Err(DdbError::DatabaseCorrupted(format!(
                             "Both header pages appear corrupted after {} attempts: ({:?}) and ({:?})",
                             GET_LATEST_HEADER_RETRIES, e0, e1
                         )));
@@ -320,16 +320,16 @@ impl Mvcc {
             }
         }
         // Unreachable due to returns in match and final error, but keep to satisfy type checker
-        Err(DCBError::DatabaseCorrupted(
+        Err(DdbError::DatabaseCorrupted(
             "Unable to read a valid header".to_string(),
         ))
     }
 
-    pub fn read_header(&self, page_id: PageID) -> DCBResult<HeaderNode> {
+    pub fn read_header(&self, page_id: PageID) -> DcbResult<HeaderNode> {
         let page = self.read_page(page_id)?;
         match page.node {
             Node::Header(node) => Ok(node),
-            _ => Err(DCBError::DatabaseCorrupted(
+            _ => Err(DdbError::DatabaseCorrupted(
                 "Invalid header node type".to_string(),
             )),
         }
@@ -345,7 +345,7 @@ impl Mvcc {
         tracking_tree_root_id: PageID,
         next_page_id: PageID,
         next_position: Position,
-    ) -> DCBResult<()> {
+    ) -> DcbResult<()> {
         let mut headers = self.headers.lock().unwrap();
         let headers_idx = { if page_id == HEADER_PAGE_ID_0 { 0 } else { 1 } };
         let header = &mut headers[headers_idx];
@@ -370,7 +370,7 @@ impl Mvcc {
         }
     }
 
-    pub fn read_page(&self, page_id: PageID) -> DCBResult<Page> {
+    pub fn read_page(&self, page_id: PageID) -> DcbResult<Page> {
         let mapped = self.pager.read_page_mmap_slice(page_id)?;
         if self.verbose {
             println!("Read {page_id:?} from file, deserializing...");
@@ -378,12 +378,12 @@ impl Mvcc {
         Page::deserialize(page_id, mapped.as_slice())
     }
 
-    pub fn fsync(&self) -> DCBResult<()> {
+    pub fn fsync(&self) -> DcbResult<()> {
         self.pager.fsync()?;
         Ok(())
     }
 
-    pub fn reader(&self) -> DCBResult<Reader> {
+    pub fn reader(&self) -> DcbResult<Reader> {
         let (header_page_id, header_node) = self.get_latest_header()?;
 
         // Generate a unique ID for this reader using the counter (lock-free)
@@ -407,7 +407,7 @@ impl Mvcc {
         Ok(reader)
     }
 
-    pub fn writer(&self) -> DCBResult<Writer> {
+    pub fn writer(&self) -> DcbResult<Writer> {
         if self.verbose {
             println!();
             println!("Constructing writer...");
@@ -441,7 +441,7 @@ impl Mvcc {
 
     /// Write one or more pages to disk using the shared preallocated page buffer.
     /// Returns the number of pages written.
-    pub fn write_pages<'a, I>(&self, pages: I) -> DCBResult<usize>
+    pub fn write_pages<'a, I>(&self, pages: I) -> DcbResult<usize>
     where
         I: IntoIterator<Item = &'a Page>,
     {
@@ -495,7 +495,7 @@ impl Mvcc {
     //     count
     // }
 
-    pub fn commit(&self, writer: &mut Writer) -> DCBResult<()> {
+    pub fn commit(&self, writer: &mut Writer) -> DcbResult<()> {
         // Process reused and freed page IDs
         if self.verbose {
             println!();
@@ -638,7 +638,7 @@ impl Writer {
     /// # Returns
     ///
     /// A `DCBResult` containing a reference to the page if found, or an error if the page could not be found.
-    pub fn get_page_ref(&mut self, mvcc: &Mvcc, page_id: PageID) -> DCBResult<&Page> {
+    pub fn get_page_ref(&mut self, mvcc: &Mvcc, page_id: PageID) -> DcbResult<&Page> {
         // Check the dirty pages first
         if self.dirty.contains_key(&page_id) {
             return Ok(self.dirty.get(&page_id).unwrap());
@@ -657,11 +657,11 @@ impl Writer {
         Ok(self.deserialized.get(&page_id).unwrap())
     }
 
-    pub fn get_mut_dirty(&mut self, page_id: PageID) -> DCBResult<&mut Page> {
+    pub fn get_mut_dirty(&mut self, page_id: PageID) -> DcbResult<&mut Page> {
         if let Some(page) = self.dirty.get_mut(&page_id) {
             Ok(page)
         } else {
-            Err(DCBError::DirtyPageNotFound(page_id.0))
+            Err(DdbError::DirtyPageNotFound(page_id.0))
         }
     }
 
@@ -669,12 +669,12 @@ impl Writer {
         self.deserialized.insert(page.page_id, page);
     }
 
-    pub fn insert_dirty(&mut self, page: Page) -> DCBResult<()> {
+    pub fn insert_dirty(&mut self, page: Page) -> DcbResult<()> {
         if self.freed_page_ids.contains(&page.page_id) {
-            return Err(DCBError::PageAlreadyFreed(page.page_id.0));
+            return Err(DdbError::PageAlreadyFreed(page.page_id.0));
         }
         if self.dirty.contains_key(&page.page_id) {
-            return Err(DCBError::PageAlreadyDirty(page.page_id.0));
+            return Err(DdbError::PageAlreadyDirty(page.page_id.0));
         }
         self.dirty.insert(page.page_id, page);
         Ok(())
@@ -691,7 +691,7 @@ impl Writer {
         next_page_id
     }
 
-    pub fn get_dirty_page_id(&mut self, page_id: PageID) -> DCBResult<PageID> {
+    pub fn get_dirty_page_id(&mut self, page_id: PageID) -> DcbResult<PageID> {
         let mut dirty_page_id = page_id;
         if !self.freed_page_ids.iter().any(|&id| id == page_id) {
             if !self.dirty.contains_key(&page_id) {
@@ -717,7 +717,7 @@ impl Writer {
                 println!("{page_id:?} is already dirty");
             }
         } else {
-            return Err(DCBError::PageAlreadyFreed(page_id.0));
+            return Err(DdbError::PageAlreadyFreed(page_id.0));
         }
         Ok(dirty_page_id)
     }
@@ -741,7 +741,7 @@ impl Writer {
         }
     }
 
-    pub fn find_reusable_page_ids(&mut self, mvcc: &Mvcc) -> DCBResult<()> {
+    pub fn find_reusable_page_ids(&mut self, mvcc: &Mvcc) -> DcbResult<()> {
         let verbose = self.verbose;
         let mut reusable_page_ids: VecDeque<(PageID, Tsn)> = VecDeque::new();
         // Get free page IDs
@@ -770,7 +770,7 @@ impl Writer {
                 match self.get_page_ref(mvcc, page_id) {
                     Ok(p) => p.node.clone(),
                     Err(e) => {
-                        return Err(DCBError::DatabaseCorrupted(format!(
+                        return Err(DdbError::DatabaseCorrupted(format!(
                             "Free list page {:?} load error: {:?}",
                             page_id, e
                         )));
@@ -825,7 +825,7 @@ impl Writer {
                                     match self.get_page_ref(mvcc, sub_id) {
                                         Ok(p) => p.node.clone(),
                                         Err(e) => {
-                                            return Err(DCBError::DatabaseCorrupted(format!(
+                                            return Err(DdbError::DatabaseCorrupted(format!(
                                                 "TSN subtree page {:?} load error: {:?}",
                                                 sub_id, e
                                             )));
@@ -846,7 +846,7 @@ impl Writer {
                                         }
                                     }
                                     other => {
-                                        return Err(DCBError::DatabaseCorrupted(format!(
+                                        return Err(DdbError::DatabaseCorrupted(format!(
                                             "Invalid node type in TSN subtree: {}",
                                             other.type_name()
                                         )));
@@ -857,7 +857,7 @@ impl Writer {
                     }
                 }
                 _ => {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Invalid node type in free list tree".to_string(),
                     ));
                 }
@@ -877,7 +877,7 @@ impl Writer {
         mvcc: &Mvcc,
         tsn: Tsn,
         freed_page_id: PageID,
-    ) -> DCBResult<()> {
+    ) -> DcbResult<()> {
         let verbose = self.verbose;
         if verbose {
             println!("Inserting {freed_page_id:?} for {tsn:?}");
@@ -895,7 +895,7 @@ impl Writer {
                 let len_keys = leaf_node.keys.len();
                 if len_keys == 0 {
                     if !leaf_node.would_fit_new_tsn_and_page_id(mvcc.max_node_size) {
-                        return Err(DCBError::InternalError("Page size too small".to_string()));
+                        return Err(DdbError::InternalError("Page size too small".to_string()));
                     }
                     plan = FreePageIDInsertStrategy::PushTsnOntoFreeListLeaf;
                 } else {
@@ -921,7 +921,7 @@ impl Writer {
                         }
                     } else {
                         // We assume freed page IDs are always inserted for the last TSN
-                        return Err(DCBError::InternalError(
+                        return Err(DdbError::InternalError(
                             "Insertion only supported for last TSN in leaf".to_string(),
                         ));
                     }
@@ -938,7 +938,7 @@ impl Writer {
                     .last()
                     .expect("FreeListInternal node should have a child");
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected FreeListInternal node".to_string(),
                 ));
             }
@@ -964,14 +964,14 @@ impl Writer {
                 // Read leaf immutably to find last_idx and current root_id
                 let leaf_snapshot = { self.get_page_ref(mvcc, dirty_leaf_page_id)? };
                 let Node::FreeListLeaf(leaf_ro) = &leaf_snapshot.node else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected FreeListLeaf node".to_string(),
                     ));
                 };
                 let last_idx = leaf_ro.keys.len() - 1;
                 let tsn_root_id = leaf_ro.values[last_idx].root_id;
                 if tsn_root_id == PageID(0) {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected TSN-subtree root_id to be set".to_string(),
                     ));
                 }
@@ -980,7 +980,7 @@ impl Writer {
                     // Now mutate the freelist leaf to update root_id
                     let dirty_leaf_page = self.get_mut_dirty(dirty_leaf_page_id)?;
                     let Node::FreeListLeaf(dirty_leaf_node2) = &mut dirty_leaf_page.node else {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Expected FreeListLeaf node".to_string(),
                         ));
                     };
@@ -991,7 +991,7 @@ impl Writer {
                 // Read leaf immutably to capture inline page_ids
                 let leaf_snapshot = { self.get_page_ref(mvcc, dirty_leaf_page_id)? };
                 let Node::FreeListLeaf(leaf_ro) = &leaf_snapshot.node else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected FreeListLeaf node".to_string(),
                     ));
                 };
@@ -1019,7 +1019,7 @@ impl Writer {
                     }
                 }
                 if initial_ids.is_empty() {
-                    return Err(DCBError::InternalError(
+                    return Err(DdbError::InternalError(
                         "Page size too small for TSN-subtree leaf with one PageID".to_string(),
                     ));
                 }
@@ -1035,7 +1035,7 @@ impl Writer {
                 // Now mutate the freelist leaf to clear inline and set root
                 let dirty_leaf_page = self.get_mut_dirty(dirty_leaf_page_id)?;
                 let Node::FreeListLeaf(dirty_leaf_node2) = &mut dirty_leaf_page.node else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected FreeListLeaf node".to_string(),
                     ));
                 };
@@ -1137,7 +1137,7 @@ impl Writer {
                 }
             }
         } else {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Expected FreeListLeaf node".to_string(),
             ));
         }
@@ -1168,7 +1168,7 @@ impl Writer {
                     println!("Nothing to replace in {dirty_page_id:?}")
                 }
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected FreeListInternal node".to_string(),
                 ));
             }
@@ -1185,7 +1185,7 @@ impl Writer {
                         );
                     }
                 } else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected FreeListInternal node".to_string(),
                     ));
                 }
@@ -1202,7 +1202,7 @@ impl Writer {
                     // Ensure we have at least 3 keys and 4 child IDs before splitting
                     if dirty_internal_node.keys.len() < 3 || dirty_internal_node.child_ids.len() < 4
                     {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Cannot split internal node with too few keys/children".to_string(),
                         ));
                     }
@@ -1244,7 +1244,7 @@ impl Writer {
 
                     split_info = Some((promoted_key, new_internal_page_id));
                 } else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected FreeListInternal node".to_string(),
                     ));
                 }
@@ -1261,7 +1261,7 @@ impl Writer {
                     println!("Replaced root {old_id:?} with {new_id:?}");
                 }
             } else {
-                return Err(DCBError::RootIDMismatch(old_id.0, new_id.0));
+                return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
             }
         }
 
@@ -1296,7 +1296,7 @@ impl Writer {
         mvcc: &Mvcc,
         root_id: PageID,
         key: PageID,
-    ) -> DCBResult<PageID> {
+    ) -> DcbResult<PageID> {
         let verbose = self.verbose;
         let mut stack: Vec<(PageID, usize)> = Vec::new();
         let mut current_id = root_id;
@@ -1314,7 +1314,7 @@ impl Writer {
                     current_id = next_id;
                 }
                 other => {
-                    return Err(DCBError::DatabaseCorrupted(format!(
+                    return Err(DdbError::DatabaseCorrupted(format!(
                         "Unexpected node type in TSN-subtree during insert: {}",
                         other.type_name()
                     )));
@@ -1327,7 +1327,7 @@ impl Writer {
         {
             let leaf_page = self.get_mut_dirty(current_id)?;
             let Node::FreeListTsnLeaf(ref mut leaf) = leaf_page.node else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected TSN-subtree leaf".to_string(),
                 ));
             };
@@ -1365,7 +1365,7 @@ impl Writer {
                             let parent_page = self.get_mut_dirty(parent_id)?;
                             let Node::FreeListTsnInternal(ref mut parent_node) = parent_page.node
                             else {
-                                return Err(DCBError::DatabaseCorrupted(
+                                return Err(DdbError::DatabaseCorrupted(
                                     "Expected TSN-subtree internal".to_string(),
                                 ));
                             };
@@ -1395,13 +1395,13 @@ impl Writer {
                             let right_child_ids: Vec<PageID> =
                                 parent_node.child_ids[mid + 1..].to_vec();
                             if right_child_ids.len() != right_keys.len() + 1 {
-                                return Err(DCBError::DatabaseCorrupted(
+                                return Err(DdbError::DatabaseCorrupted(
                                     "TSN-subtree internal split produced invalid right arity"
                                         .to_string(),
                                 ));
                             }
                             if left_child_ids.len() != left_keys.len() + 1 {
-                                return Err(DCBError::DatabaseCorrupted(
+                                return Err(DdbError::DatabaseCorrupted(
                                     "TSN-subtree internal split produced invalid left arity"
                                         .to_string(),
                                 ));
@@ -1453,7 +1453,7 @@ impl Writer {
         mvcc: &Mvcc,
         tsn: Tsn,
         used_page_id: PageID,
-    ) -> DCBResult<()> {
+    ) -> DcbResult<()> {
         let verbose = self.verbose;
         if verbose {
             println!();
@@ -1479,7 +1479,7 @@ impl Writer {
                 stack.push(current_page_id);
                 current_page_id = *internal_node.child_ids.first().unwrap();
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected FreeListInternal node".to_string(),
                 ));
             }
@@ -1496,12 +1496,12 @@ impl Writer {
         // Read the current leaf immutably to decide the path (inline vs TSN-subtree)
         let leaf_snapshot = { self.get_page_ref(mvcc, current_page_id)? };
         let Node::FreeListLeaf(leaf_node_ro) = &leaf_snapshot.node else {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Expected FreeListLeaf node".to_string(),
             ));
         };
         if leaf_node_ro.keys.is_empty() || leaf_node_ro.keys[0] != tsn {
-            return Err(DCBError::DatabaseCorrupted(format!(
+            return Err(DdbError::DatabaseCorrupted(format!(
                 "Expected TSN {} not found: {:?}",
                 tsn.0, leaf_node_ro
             )));
@@ -1529,7 +1529,7 @@ impl Writer {
                 {
                     leaf_value.page_ids.remove(pos);
                 } else {
-                    return Err(DCBError::DatabaseCorrupted(format!(
+                    return Err(DdbError::DatabaseCorrupted(format!(
                         "{used_page_id:?} not found in {tsn:?}"
                     )));
                 }
@@ -1554,7 +1554,7 @@ impl Writer {
                     println!("Leaf value not empty {tsn:?}: {leaf_value:?}");
                 }
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected FreeListLeaf node".to_string(),
                 ));
             }
@@ -1575,7 +1575,7 @@ impl Writer {
                     {
                         tsn_leaf_node.page_ids.remove(pos);
                     } else {
-                        return Err(DCBError::DatabaseCorrupted(format!(
+                        return Err(DdbError::DatabaseCorrupted(format!(
                             "{used_page_id:?} not found in TSN-subtree for {tsn:?}"
                         )));
                     }
@@ -1620,7 +1620,7 @@ impl Writer {
                                 current_id = next_id;
                             }
                             other => {
-                                return Err(DCBError::DatabaseCorrupted(format!(
+                                return Err(DdbError::DatabaseCorrupted(format!(
                                     "Unexpected node type in TSN-subtree during descent: {}",
                                     other.type_name()
                                 )));
@@ -1639,7 +1639,7 @@ impl Writer {
                                 {
                                     leaf_node.page_ids.remove(pos);
                                 } else {
-                                    return Err(DCBError::DatabaseCorrupted(format!(
+                                    return Err(DdbError::DatabaseCorrupted(format!(
                                         "{used_page_id:?} not found in TSN-subtree for {tsn:?}"
                                     )));
                                 }
@@ -1654,7 +1654,7 @@ impl Writer {
                                 }
                             }
                             other => {
-                                return Err(DCBError::DatabaseCorrupted(format!(
+                                return Err(DdbError::DatabaseCorrupted(format!(
                                     "Expected TSN-subtree leaf, got {}",
                                     other.type_name()
                                 )));
@@ -1678,7 +1678,7 @@ impl Writer {
                         let parent_page = self.get_mut_dirty(parent_dirty_id)?;
                         let Node::FreeListTsnInternal(ref mut parent_node) = parent_page.node
                         else {
-                            return Err(DCBError::DatabaseCorrupted(
+                            return Err(DdbError::DatabaseCorrupted(
                                 "Expected TSN-subtree internal node".to_string(),
                             ));
                         };
@@ -1741,7 +1741,7 @@ impl Writer {
                     }
                 }
                 _ => {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected TSN-subtree node".to_string(),
                     ));
                 }
@@ -1756,7 +1756,7 @@ impl Writer {
             if let Node::FreeListLeaf(dirty_leaf_node) = &mut dirty_leaf_page.node {
                 // Ensure expected TSN still at index 0
                 if dirty_leaf_node.keys.is_empty() || dirty_leaf_node.keys[0] != tsn {
-                    return Err(DCBError::DatabaseCorrupted(format!(
+                    return Err(DdbError::DatabaseCorrupted(format!(
                         "Expected TSN {} not found in dirty leaf: {:?}",
                         tsn.0, dirty_leaf_node
                     )));
@@ -1784,7 +1784,7 @@ impl Writer {
                     dirty_leaf_node.values[0].root_id = dirty_tsn_root_id;
                 }
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected FreeListLeaf node".to_string(),
                 ));
             }
@@ -1817,10 +1817,10 @@ impl Writer {
                             );
                         }
                     } else {
-                        return Err(DCBError::DatabaseCorrupted("Child ID mismatch".to_string()));
+                        return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
                     }
                 } else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected FreeListInternal node".to_string(),
                     ));
                 }
@@ -1833,10 +1833,10 @@ impl Writer {
                 if let Node::FreeListInternal(dirty_internal_node) = &mut dirty_internal_page.node {
                     // Remove the child ID and key
                     if dirty_internal_node.child_ids[0] != removed_page_id {
-                        return Err(DCBError::DatabaseCorrupted("Child ID mismatch".to_string()));
+                        return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
                     }
                     if dirty_internal_node.keys.is_empty() {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Empty internal node keys".to_string(),
                         ));
                     }
@@ -1867,7 +1867,7 @@ impl Writer {
                         }
                     }
                 } else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected FreeListInternal node".to_string(),
                     ));
                 }
@@ -1890,7 +1890,7 @@ impl Writer {
                     println!("Replaced root {old_id:?} with {new_id:?}");
                 }
             } else {
-                return Err(DCBError::RootIDMismatch(old_id.0, new_id.0));
+                return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
             }
         }
 
@@ -4293,7 +4293,7 @@ mod tests {
             // 4) Attempt to open again; expect an InternalError complaining about schema version
             match Mvcc::new(&db_path, page_size, verbose) {
                 Ok(_) => panic!("opening should have failed due to newer on-disk schema"),
-                Err(DCBError::InternalError(msg)) => {
+                Err(DdbError::InternalError(msg)) => {
                     assert!(
                         msg.contains("Software version is too old"),
                         "unexpected error message: {msg}"

--- a/umadb-core/src/node.rs
+++ b/umadb-core/src/node.rs
@@ -5,7 +5,7 @@ use crate::free_lists_tree_nodes::{
 use crate::header_node::HeaderNode;
 use crate::tags_tree_nodes::{TagInternalNode, TagLeafNode, TagsInternalNode, TagsLeafNode};
 use crate::tracking_tree_nodes::{TrackingInternalNode, TrackingLeafNode};
-use umadb_dcb::{DCBError, DCBResult};
+use umadb_dcb::{DdbError, DcbResult};
 
 // Constants for serialization
 const PAGE_TYPE_HEADER: u8 = b'1';
@@ -103,7 +103,7 @@ impl Node {
     /// No-allocation serialization into a provided buffer slice.
     /// Returns the number of bytes written.
     /// Implemented for key node types; for others it falls back to allocate-and-copy.
-    pub fn serialize_into(&self, buf: &mut [u8]) -> DCBResult<usize> {
+    pub fn serialize_into(&self, buf: &mut [u8]) -> DcbResult<usize> {
         match self {
             Node::Header(node) => {
                 let n = node.serialize_into(buf);
@@ -164,7 +164,7 @@ impl Node {
         }
     }
 
-    pub fn deserialize(node_type: u8, data: &[u8]) -> DCBResult<Self> {
+    pub fn deserialize(node_type: u8, data: &[u8]) -> DcbResult<Self> {
         match node_type {
             PAGE_TYPE_HEADER => {
                 let node = HeaderNode::from_slice(data)?;
@@ -222,7 +222,7 @@ impl Node {
                 let node = TrackingInternalNode::from_slice(data)?;
                 Ok(Node::TrackingInternal(node))
             }
-            _ => Err(DCBError::DatabaseCorrupted(format!(
+            _ => Err(DdbError::DatabaseCorrupted(format!(
                 "Invalid node type: {node_type}"
             ))),
         }

--- a/umadb-core/src/node.rs
+++ b/umadb-core/src/node.rs
@@ -5,7 +5,7 @@ use crate::free_lists_tree_nodes::{
 use crate::header_node::HeaderNode;
 use crate::tags_tree_nodes::{TagInternalNode, TagLeafNode, TagsInternalNode, TagsLeafNode};
 use crate::tracking_tree_nodes::{TrackingInternalNode, TrackingLeafNode};
-use umadb_dcb::{DdbError, DcbResult};
+use umadb_dcb::{DcbError, DcbResult};
 
 // Constants for serialization
 const PAGE_TYPE_HEADER: u8 = b'1';
@@ -222,7 +222,7 @@ impl Node {
                 let node = TrackingInternalNode::from_slice(data)?;
                 Ok(Node::TrackingInternal(node))
             }
-            _ => Err(DdbError::DatabaseCorrupted(format!(
+            _ => Err(DcbError::DatabaseCorrupted(format!(
                 "Invalid node type: {node_type}"
             ))),
         }

--- a/umadb-core/src/page.rs
+++ b/umadb-core/src/page.rs
@@ -1,7 +1,7 @@
 use crate::common::PageID;
 use crate::node::Node;
 use std::ops::Range;
-use umadb_dcb::{DdbError, DcbResult};
+use umadb_dcb::{DcbError, DcbResult};
 
 // Page structure
 #[derive(Debug, Clone)]
@@ -37,7 +37,7 @@ impl Page {
     #[inline]
     pub fn deserialize(page_id: PageID, page_data: &[u8]) -> DcbResult<Self> {
         if page_data.len() < PAGE_HEADER_SIZE {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Page data too short".to_string(),
             ));
         }
@@ -50,7 +50,7 @@ impl Page {
             u32::from_le_bytes(header[HEADER_LAYOUT_BODY_LEN_BYTES].try_into().unwrap()) as usize;
 
         if PAGE_HEADER_SIZE + data_len > page_data.len() {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Page data length mismatch".to_string(),
             ));
         }
@@ -62,7 +62,7 @@ impl Page {
         let calculated_crc = calc_crc(data);
 
         if calculated_crc != crc {
-            return Err(DdbError::DatabaseCorrupted(format!(
+            return Err(DcbError::DatabaseCorrupted(format!(
                 "CRC mismatch (page ID: {page_id:?})"
             )));
         }

--- a/umadb-core/src/page.rs
+++ b/umadb-core/src/page.rs
@@ -1,7 +1,7 @@
 use crate::common::PageID;
 use crate::node::Node;
 use std::ops::Range;
-use umadb_dcb::{DCBError, DCBResult};
+use umadb_dcb::{DdbError, DcbResult};
 
 // Page structure
 #[derive(Debug, Clone)]
@@ -29,15 +29,15 @@ impl Page {
     }
 
     /// Serialized page (header + body + zero padding) into `buf`.
-    pub fn serialize_into(&self, buf: &mut [u8]) -> DCBResult<()> {
+    pub fn serialize_into(&self, buf: &mut [u8]) -> DcbResult<()> {
         serialize_page_into(buf, &self.node)?;
         Ok(())
     }
 
     #[inline]
-    pub fn deserialize(page_id: PageID, page_data: &[u8]) -> DCBResult<Self> {
+    pub fn deserialize(page_id: PageID, page_data: &[u8]) -> DcbResult<Self> {
         if page_data.len() < PAGE_HEADER_SIZE {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Page data too short".to_string(),
             ));
         }
@@ -50,7 +50,7 @@ impl Page {
             u32::from_le_bytes(header[HEADER_LAYOUT_BODY_LEN_BYTES].try_into().unwrap()) as usize;
 
         if PAGE_HEADER_SIZE + data_len > page_data.len() {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Page data length mismatch".to_string(),
             ));
         }
@@ -62,7 +62,7 @@ impl Page {
         let calculated_crc = calc_crc(data);
 
         if calculated_crc != crc {
-            return Err(DCBError::DatabaseCorrupted(format!(
+            return Err(DdbError::DatabaseCorrupted(format!(
                 "CRC mismatch (page ID: {page_id:?})"
             )));
         }
@@ -74,14 +74,14 @@ impl Page {
     }
 }
 
-pub fn serialize_page_into(buf: &mut [u8], node_ref: &Node) -> DCBResult<()> {
+pub fn serialize_page_into(buf: &mut [u8], node_ref: &Node) -> DcbResult<()> {
     let body_len = serialize_page_node_into(buf, node_ref)?;
     serialize_page_header_into(buf, body_len, node_ref.get_type_byte());
     Ok(())
 }
 
 #[inline(always)]
-fn serialize_page_node_into(buf: &mut [u8], node_ref: &Node) -> DCBResult<usize> {
+fn serialize_page_node_into(buf: &mut [u8], node_ref: &Node) -> DcbResult<usize> {
     // Serialize body into the front of the body region using the space after header
     let body_len = {
         let body_slice = &mut buf[PAGE_HEADER_SIZE..];

--- a/umadb-core/src/pager.rs
+++ b/umadb-core/src/pager.rs
@@ -10,7 +10,7 @@ use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
-use umadb_dcb::{DCBError, DCBResult};
+use umadb_dcb::{DdbError, DcbResult};
 
 // Pager for file I/O
 #[derive(Debug)]
@@ -36,7 +36,7 @@ impl Drop for Pager {
 
 // Implementation for Pager
 impl Pager {
-    pub fn new(path: &Path, page_size: usize) -> DCBResult<Self> {
+    pub fn new(path: &Path, page_size: usize) -> DcbResult<Self> {
         let is_file_new = !path.exists();
 
         let file = match if is_file_new {
@@ -51,7 +51,7 @@ impl Pager {
         } {
             Ok(file) => file,
             Err(err) => {
-                return Err(DCBError::InitializationError(format!(
+                return Err(DdbError::InitializationError(format!(
                     "Couldn't open database file {}: {}",
                     path.display(),
                     err
@@ -65,12 +65,12 @@ impl Pager {
         if let Err(err) = Fs2FileExt::try_lock_exclusive(&file) {
             use std::io::ErrorKind;
             if err.kind() == ErrorKind::WouldBlock {
-                return Err(DCBError::InitializationError(format!(
+                return Err(DdbError::InitializationError(format!(
                     "Database file {} is already locked (another process/container may be using it).",
                     path.display()
                 )));
             } else {
-                return Err(DCBError::InitializationError(format!(
+                return Err(DdbError::InitializationError(format!(
                     "Failed to acquire exclusive lock on database file {}: {}",
                     path.display(),
                     err
@@ -356,10 +356,10 @@ impl Pager {
         })
     }
 
-    pub fn write_page(&self, page_id: PageID, page_data: &[u8]) -> DCBResult<()> {
+    pub fn write_page(&self, page_id: PageID, page_data: &[u8]) -> DcbResult<()> {
         // Check the page doesn't overflow the page size.
         if page_data.len() != self.page_size {
-            return Err(DCBError::InternalError(format!(
+            return Err(DdbError::InternalError(format!(
                 "Page size mismatch: page_id={:?} size={} > PAGE_SIZE={}",
                 page_id,
                 page_data.len(),
@@ -375,7 +375,7 @@ impl Pager {
                 (self.mmap_pages_per_map * self.page_size) as u64,
             )
         {
-            return Err(DCBError::Io(err));
+            return Err(DdbError::Io(err));
         }
 
         // Write the page data
@@ -539,7 +539,7 @@ mod tests {
     use crate::common::PageID;
     use std::path::PathBuf;
     use tempfile::tempdir;
-    use umadb_dcb::DCBError;
+    use umadb_dcb::DdbError;
 
     fn temp_file_path(name: &str) -> PathBuf {
         let dir = tempdir().expect("tempdir");
@@ -555,7 +555,7 @@ mod tests {
         let data1 = vec![1u8; 100];
 
         let err = pager.write_page(PageID(0), &data1);
-        assert!(matches!(err, Err(DCBError::InternalError(_))));
+        assert!(matches!(err, Err(DdbError::InternalError(_))));
     }
 
     #[test]
@@ -688,7 +688,7 @@ mod tests {
         // While pager is open, attempting to open a second Pager should fail with InitializationError
         let err = Pager::new(&path, page_size).unwrap_err();
         match err {
-            DCBError::InitializationError(msg) => {
+            DdbError::InitializationError(msg) => {
                 assert!(msg.contains("already locked"), "unexpected error: {}", msg);
             }
             other => panic!("expected InitializationError, got {:?}", other),

--- a/umadb-core/src/pager.rs
+++ b/umadb-core/src/pager.rs
@@ -10,7 +10,7 @@ use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
-use umadb_dcb::{DdbError, DcbResult};
+use umadb_dcb::{DcbError, DcbResult};
 
 // Pager for file I/O
 #[derive(Debug)]
@@ -51,7 +51,7 @@ impl Pager {
         } {
             Ok(file) => file,
             Err(err) => {
-                return Err(DdbError::InitializationError(format!(
+                return Err(DcbError::InitializationError(format!(
                     "Couldn't open database file {}: {}",
                     path.display(),
                     err
@@ -65,12 +65,12 @@ impl Pager {
         if let Err(err) = Fs2FileExt::try_lock_exclusive(&file) {
             use std::io::ErrorKind;
             if err.kind() == ErrorKind::WouldBlock {
-                return Err(DdbError::InitializationError(format!(
+                return Err(DcbError::InitializationError(format!(
                     "Database file {} is already locked (another process/container may be using it).",
                     path.display()
                 )));
             } else {
-                return Err(DdbError::InitializationError(format!(
+                return Err(DcbError::InitializationError(format!(
                     "Failed to acquire exclusive lock on database file {}: {}",
                     path.display(),
                     err
@@ -359,7 +359,7 @@ impl Pager {
     pub fn write_page(&self, page_id: PageID, page_data: &[u8]) -> DcbResult<()> {
         // Check the page doesn't overflow the page size.
         if page_data.len() != self.page_size {
-            return Err(DdbError::InternalError(format!(
+            return Err(DcbError::InternalError(format!(
                 "Page size mismatch: page_id={:?} size={} > PAGE_SIZE={}",
                 page_id,
                 page_data.len(),
@@ -375,7 +375,7 @@ impl Pager {
                 (self.mmap_pages_per_map * self.page_size) as u64,
             )
         {
-            return Err(DdbError::Io(err));
+            return Err(DcbError::Io(err));
         }
 
         // Write the page data
@@ -539,7 +539,7 @@ mod tests {
     use crate::common::PageID;
     use std::path::PathBuf;
     use tempfile::tempdir;
-    use umadb_dcb::DdbError;
+    use umadb_dcb::DcbError;
 
     fn temp_file_path(name: &str) -> PathBuf {
         let dir = tempdir().expect("tempdir");
@@ -555,7 +555,7 @@ mod tests {
         let data1 = vec![1u8; 100];
 
         let err = pager.write_page(PageID(0), &data1);
-        assert!(matches!(err, Err(DdbError::InternalError(_))));
+        assert!(matches!(err, Err(DcbError::InternalError(_))));
     }
 
     #[test]
@@ -688,7 +688,7 @@ mod tests {
         // While pager is open, attempting to open a second Pager should fail with InitializationError
         let err = Pager::new(&path, page_size).unwrap_err();
         match err {
-            DdbError::InitializationError(msg) => {
+            DcbError::InitializationError(msg) => {
                 assert!(msg.contains("already locked"), "unexpected error: {}", msg);
             }
             other => panic!("expected InitializationError, got {:?}", other),

--- a/umadb-core/src/tags_tree.rs
+++ b/umadb-core/src/tags_tree.rs
@@ -6,7 +6,7 @@ use crate::tags_tree_nodes::{
     TagHash, TagInternalNode, TagLeafNode, TagsInternalNode, TagsLeafNode, TagsLeafValue,
 };
 use std::collections::HashMap;
-use umadb_dcb::{DCBError, DCBResult};
+use umadb_dcb::{DdbError, DcbResult};
 
 /// Insert a Position into the tags tree at the given TagHash key.
 ///
@@ -21,7 +21,7 @@ pub fn tags_tree_insert(
     writer: &mut Writer,
     tag: TagHash,
     pos: Position,
-) -> DCBResult<()> {
+) -> DcbResult<()> {
     let verbose = mvcc.verbose;
     if verbose {
         println!("Inserting position {pos:?} for tag {tag:?}");
@@ -52,7 +52,7 @@ pub fn tags_tree_insert(
                 current_page_id = internal_node.child_ids[child_idx];
             }
             _ => {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Invalid node type in tags tree (expected TagsInternal/TagsLeaf)".to_string(),
                 ));
             }
@@ -112,7 +112,7 @@ pub fn tags_tree_insert(
                 }
             }
             _ => {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected TagsLeaf node".to_string(),
                 ));
             }
@@ -135,11 +135,11 @@ pub fn tags_tree_insert(
                 let leaf_page = writer.get_mut_dirty(dirty_leaf_page_id)?;
                 if let Node::TagsLeaf(leaf) = &mut leaf_page.node {
                     let idx = leaf.keys.binary_search(&tag).map_err(|_| {
-                        DCBError::DatabaseCorrupted("Tag key not found after COW".to_string())
+                        DdbError::DatabaseCorrupted("Tag key not found after COW".to_string())
                     })?;
                     leaf.values[idx].root_id = tag_root_id;
                 } else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected TagsLeaf node".to_string(),
                     ));
                 }
@@ -163,7 +163,7 @@ pub fn tags_tree_insert(
                     }
                     Node::TagLeaf(_) => break,
                     _ => {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Expected per-tag TagInternal/TagLeaf".to_string(),
                         ));
                     }
@@ -190,7 +190,7 @@ pub fn tags_tree_insert(
                             // Move last pos to a new right leaf
                             let last_pos = tleaf
                                 .pop_last_position()
-                                .map_err(|e| DCBError::DatabaseCorrupted(format!("{e}")))?;
+                                .map_err(|e| DdbError::DatabaseCorrupted(format!("{e}")))?;
                             let right_id = {
                                 let id = writer.alloc_page_id();
                                 let page = Page::new(
@@ -206,7 +206,7 @@ pub fn tags_tree_insert(
                         }
                     }
                     _ => {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Expected TagLeaf at per-tag insert".to_string(),
                         ));
                     }
@@ -230,12 +230,12 @@ pub fn tags_tree_insert(
                         if internal.child_ids[child_idx] == old_id {
                             internal.child_ids[child_idx] = new_id;
                         } else {
-                            return Err(DCBError::DatabaseCorrupted(
+                            return Err(DdbError::DatabaseCorrupted(
                                 "Per-tag parent did not contain expected child id".to_string(),
                             ));
                         }
                     } else {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Expected TagInternal".to_string(),
                         ));
                     }
@@ -248,7 +248,7 @@ pub fn tags_tree_insert(
                         internal.keys.insert(child_idx, promoted_key);
                         internal.child_ids.insert(child_idx + 1, new_child_id);
                     } else {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Expected TagInternal".to_string(),
                         ));
                     }
@@ -260,7 +260,7 @@ pub fn tags_tree_insert(
                 if needs_split {
                     if let Node::TagInternal(internal) = &mut parent_page.node {
                         if internal.keys.len() < 3 || internal.child_ids.len() < 4 {
-                            return Err(DCBError::DatabaseCorrupted(
+                            return Err(DdbError::DatabaseCorrupted(
                                 "Cannot split per-tag internal with too few keys/children"
                                     .to_string(),
                             ));
@@ -276,7 +276,7 @@ pub fn tags_tree_insert(
                         writer.insert_dirty(new_internal_page)?;
                         split_info = Some((promote_up, new_internal_id));
                     } else {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Expected TagInternal".to_string(),
                         ));
                     }
@@ -291,7 +291,7 @@ pub fn tags_tree_insert(
                 if tag_root_id == old_id {
                     tag_root_id = new_id;
                 } else {
-                    return Err(DCBError::RootIDMismatch(old_id.0, new_id.0));
+                    return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
                 }
             }
 
@@ -311,13 +311,13 @@ pub fn tags_tree_insert(
             let leaf_page = writer.get_mut_dirty(dirty_leaf_page_id)?;
             if let Node::TagsLeaf(leaf) = &mut leaf_page.node {
                 let idx = leaf.keys.binary_search(&tag).map_err(|_| {
-                    DCBError::DatabaseCorrupted(
+                    DdbError::DatabaseCorrupted(
                         "Tag key not found after per-tag insert".to_string(),
                     )
                 })?;
                 leaf.values[idx].root_id = tag_root_id;
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected TagsLeaf node".to_string(),
                 ));
             }
@@ -339,7 +339,7 @@ pub fn tags_tree_insert(
                 if let Node::TagsLeaf(leaf) = &mut leaf_page.node {
                     std::mem::take(&mut leaf.values[i].positions)
                 } else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Expected TagsLeaf node".to_string(),
                     ));
                 }
@@ -363,7 +363,7 @@ pub fn tags_tree_insert(
                 } else {
                     // Split: move the last position to the right leaf and create an internal root
                     let last_pos = pos_vec.pop().ok_or_else(|| {
-                        DCBError::DatabaseCorrupted("No positions to split".to_string())
+                        DdbError::DatabaseCorrupted("No positions to split".to_string())
                     })?;
                     let left_bytes = crate::page::PAGE_HEADER_SIZE
                         + TagLeafNode {
@@ -371,7 +371,7 @@ pub fn tags_tree_insert(
                         }
                         .calc_serialized_size();
                     if left_bytes > mvcc.page_size {
-                        return Err(DCBError::DatabaseCorrupted(
+                        return Err(DdbError::DatabaseCorrupted(
                             "Recursive per-tag split not implemented".to_string(),
                         ));
                     }
@@ -409,7 +409,7 @@ pub fn tags_tree_insert(
             if let Node::TagsLeaf(leaf) = &mut leaf_page.node {
                 leaf.values[i].root_id = new_root_id;
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected TagsLeaf node".to_string(),
                 ));
             }
@@ -477,7 +477,7 @@ pub fn tags_tree_insert(
                         );
                     }
                 } else {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Parent did not contain expected child id".to_string(),
                     ));
                 }
@@ -485,7 +485,7 @@ pub fn tags_tree_insert(
                 println!("No child replacement needed in {dirty_parent_page_id:?}");
             }
         } else {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Expected TagsInternal node".to_string(),
             ));
         }
@@ -503,7 +503,7 @@ pub fn tags_tree_insert(
                     );
                 }
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected TagsInternal node".to_string(),
                 ));
             }
@@ -517,7 +517,7 @@ pub fn tags_tree_insert(
                     println!("Splitting TagsInternal {dirty_parent_page_id:?}...");
                 }
                 if internal.keys.len() < 3 || internal.child_ids.len() < 4 {
-                    return Err(DCBError::DatabaseCorrupted(
+                    return Err(DdbError::DatabaseCorrupted(
                         "Cannot split internal node with too few keys/children".to_string(),
                     ));
                 }
@@ -537,7 +537,7 @@ pub fn tags_tree_insert(
                 writer.insert_dirty(new_internal_page)?;
                 split_info = Some((promote_up, new_internal_id));
             } else {
-                return Err(DCBError::DatabaseCorrupted(
+                return Err(DdbError::DatabaseCorrupted(
                     "Expected TagsInternal node".to_string(),
                 ));
             }
@@ -557,7 +557,7 @@ pub fn tags_tree_insert(
                 println!("Replaced Tags root {old_id:?} -> {new_id:?}");
             }
         } else {
-            return Err(DCBError::RootIDMismatch(old_id.0, new_id.0));
+            return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
         }
     }
 
@@ -868,7 +868,7 @@ impl<'a> TagsTreeIterator<'a> {
         false
     }
 
-    fn get_page_cached(&mut self, page_id: PageID) -> DCBResult<&Page> {
+    fn get_page_cached(&mut self, page_id: PageID) -> DcbResult<&Page> {
         if let Some(p) = self.dirty.get(&page_id) {
             return Ok(p);
         }
@@ -937,7 +937,7 @@ mod tests {
         tag: TagHash,
         from: Position,
         backwards: bool,
-    ) -> DCBResult<Vec<Position>> {
+    ) -> DcbResult<Vec<Position>> {
         // Reuse the iterator to traverse and collect all positions for the tag
         let dirty = HashMap::new();
         let iter = TagsTreeIterator::new(mvcc, &dirty, tags_root_id, tag, Some(from), backwards);

--- a/umadb-core/src/tags_tree.rs
+++ b/umadb-core/src/tags_tree.rs
@@ -6,7 +6,7 @@ use crate::tags_tree_nodes::{
     TagHash, TagInternalNode, TagLeafNode, TagsInternalNode, TagsLeafNode, TagsLeafValue,
 };
 use std::collections::HashMap;
-use umadb_dcb::{DdbError, DcbResult};
+use umadb_dcb::{DcbError, DcbResult};
 
 /// Insert a Position into the tags tree at the given TagHash key.
 ///
@@ -52,7 +52,7 @@ pub fn tags_tree_insert(
                 current_page_id = internal_node.child_ids[child_idx];
             }
             _ => {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Invalid node type in tags tree (expected TagsInternal/TagsLeaf)".to_string(),
                 ));
             }
@@ -112,7 +112,7 @@ pub fn tags_tree_insert(
                 }
             }
             _ => {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected TagsLeaf node".to_string(),
                 ));
             }
@@ -135,11 +135,11 @@ pub fn tags_tree_insert(
                 let leaf_page = writer.get_mut_dirty(dirty_leaf_page_id)?;
                 if let Node::TagsLeaf(leaf) = &mut leaf_page.node {
                     let idx = leaf.keys.binary_search(&tag).map_err(|_| {
-                        DdbError::DatabaseCorrupted("Tag key not found after COW".to_string())
+                        DcbError::DatabaseCorrupted("Tag key not found after COW".to_string())
                     })?;
                     leaf.values[idx].root_id = tag_root_id;
                 } else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected TagsLeaf node".to_string(),
                     ));
                 }
@@ -163,7 +163,7 @@ pub fn tags_tree_insert(
                     }
                     Node::TagLeaf(_) => break,
                     _ => {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Expected per-tag TagInternal/TagLeaf".to_string(),
                         ));
                     }
@@ -190,7 +190,7 @@ pub fn tags_tree_insert(
                             // Move last pos to a new right leaf
                             let last_pos = tleaf
                                 .pop_last_position()
-                                .map_err(|e| DdbError::DatabaseCorrupted(format!("{e}")))?;
+                                .map_err(|e| DcbError::DatabaseCorrupted(format!("{e}")))?;
                             let right_id = {
                                 let id = writer.alloc_page_id();
                                 let page = Page::new(
@@ -206,7 +206,7 @@ pub fn tags_tree_insert(
                         }
                     }
                     _ => {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Expected TagLeaf at per-tag insert".to_string(),
                         ));
                     }
@@ -230,12 +230,12 @@ pub fn tags_tree_insert(
                         if internal.child_ids[child_idx] == old_id {
                             internal.child_ids[child_idx] = new_id;
                         } else {
-                            return Err(DdbError::DatabaseCorrupted(
+                            return Err(DcbError::DatabaseCorrupted(
                                 "Per-tag parent did not contain expected child id".to_string(),
                             ));
                         }
                     } else {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Expected TagInternal".to_string(),
                         ));
                     }
@@ -248,7 +248,7 @@ pub fn tags_tree_insert(
                         internal.keys.insert(child_idx, promoted_key);
                         internal.child_ids.insert(child_idx + 1, new_child_id);
                     } else {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Expected TagInternal".to_string(),
                         ));
                     }
@@ -260,7 +260,7 @@ pub fn tags_tree_insert(
                 if needs_split {
                     if let Node::TagInternal(internal) = &mut parent_page.node {
                         if internal.keys.len() < 3 || internal.child_ids.len() < 4 {
-                            return Err(DdbError::DatabaseCorrupted(
+                            return Err(DcbError::DatabaseCorrupted(
                                 "Cannot split per-tag internal with too few keys/children"
                                     .to_string(),
                             ));
@@ -276,7 +276,7 @@ pub fn tags_tree_insert(
                         writer.insert_dirty(new_internal_page)?;
                         split_info = Some((promote_up, new_internal_id));
                     } else {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Expected TagInternal".to_string(),
                         ));
                     }
@@ -291,7 +291,7 @@ pub fn tags_tree_insert(
                 if tag_root_id == old_id {
                     tag_root_id = new_id;
                 } else {
-                    return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
+                    return Err(DcbError::RootIDMismatch(old_id.0, new_id.0));
                 }
             }
 
@@ -311,13 +311,13 @@ pub fn tags_tree_insert(
             let leaf_page = writer.get_mut_dirty(dirty_leaf_page_id)?;
             if let Node::TagsLeaf(leaf) = &mut leaf_page.node {
                 let idx = leaf.keys.binary_search(&tag).map_err(|_| {
-                    DdbError::DatabaseCorrupted(
+                    DcbError::DatabaseCorrupted(
                         "Tag key not found after per-tag insert".to_string(),
                     )
                 })?;
                 leaf.values[idx].root_id = tag_root_id;
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected TagsLeaf node".to_string(),
                 ));
             }
@@ -339,7 +339,7 @@ pub fn tags_tree_insert(
                 if let Node::TagsLeaf(leaf) = &mut leaf_page.node {
                     std::mem::take(&mut leaf.values[i].positions)
                 } else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Expected TagsLeaf node".to_string(),
                     ));
                 }
@@ -363,7 +363,7 @@ pub fn tags_tree_insert(
                 } else {
                     // Split: move the last position to the right leaf and create an internal root
                     let last_pos = pos_vec.pop().ok_or_else(|| {
-                        DdbError::DatabaseCorrupted("No positions to split".to_string())
+                        DcbError::DatabaseCorrupted("No positions to split".to_string())
                     })?;
                     let left_bytes = crate::page::PAGE_HEADER_SIZE
                         + TagLeafNode {
@@ -371,7 +371,7 @@ pub fn tags_tree_insert(
                         }
                         .calc_serialized_size();
                     if left_bytes > mvcc.page_size {
-                        return Err(DdbError::DatabaseCorrupted(
+                        return Err(DcbError::DatabaseCorrupted(
                             "Recursive per-tag split not implemented".to_string(),
                         ));
                     }
@@ -409,7 +409,7 @@ pub fn tags_tree_insert(
             if let Node::TagsLeaf(leaf) = &mut leaf_page.node {
                 leaf.values[i].root_id = new_root_id;
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected TagsLeaf node".to_string(),
                 ));
             }
@@ -477,7 +477,7 @@ pub fn tags_tree_insert(
                         );
                     }
                 } else {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Parent did not contain expected child id".to_string(),
                     ));
                 }
@@ -485,7 +485,7 @@ pub fn tags_tree_insert(
                 println!("No child replacement needed in {dirty_parent_page_id:?}");
             }
         } else {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Expected TagsInternal node".to_string(),
             ));
         }
@@ -503,7 +503,7 @@ pub fn tags_tree_insert(
                     );
                 }
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected TagsInternal node".to_string(),
                 ));
             }
@@ -517,7 +517,7 @@ pub fn tags_tree_insert(
                     println!("Splitting TagsInternal {dirty_parent_page_id:?}...");
                 }
                 if internal.keys.len() < 3 || internal.child_ids.len() < 4 {
-                    return Err(DdbError::DatabaseCorrupted(
+                    return Err(DcbError::DatabaseCorrupted(
                         "Cannot split internal node with too few keys/children".to_string(),
                     ));
                 }
@@ -537,7 +537,7 @@ pub fn tags_tree_insert(
                 writer.insert_dirty(new_internal_page)?;
                 split_info = Some((promote_up, new_internal_id));
             } else {
-                return Err(DdbError::DatabaseCorrupted(
+                return Err(DcbError::DatabaseCorrupted(
                     "Expected TagsInternal node".to_string(),
                 ));
             }
@@ -557,7 +557,7 @@ pub fn tags_tree_insert(
                 println!("Replaced Tags root {old_id:?} -> {new_id:?}");
             }
         } else {
-            return Err(DdbError::RootIDMismatch(old_id.0, new_id.0));
+            return Err(DcbError::RootIDMismatch(old_id.0, new_id.0));
         }
     }
 

--- a/umadb-core/src/tags_tree_nodes.rs
+++ b/umadb-core/src/tags_tree_nodes.rs
@@ -1,7 +1,7 @@
 use crate::common::{PageID, Position};
 use byteorder::{ByteOrder, LittleEndian};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use umadb_dcb::{DdbError, DcbResult};
+use umadb_dcb::{DcbError, DcbResult};
 
 /// Length in bytes of the hashed tag key used in-memory for TagHash
 pub const TAG_HASH_LEN: usize = 16;
@@ -98,7 +98,7 @@ impl TagsLeafNode {
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         let slice_len = slice.len();
         if slice_len < 2 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice_len
             )));
@@ -111,7 +111,7 @@ impl TagsLeafNode {
         let keyw = get_tag_key_width();
         let keys_bytes = 2 + keys_len * keyw;
         if slice_len < keys_bytes {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 keys_bytes, slice_len
             )));
@@ -134,7 +134,7 @@ impl TagsLeafNode {
             if offset + need > slice_len {
                 let key_number = i + 1;
                 let shortfall = offset + need - slice_len;
-                return Err(DdbError::DeserializationError(format!(
+                return Err(DcbError::DeserializationError(format!(
                     "Unexpected end of data while reading tags leaf value header for key {key_number}/{keys_len}: shortfall: {shortfall}, slice len: {slice_len}, offset: {offset}, need: {need}"
                 )));
             }
@@ -151,7 +151,7 @@ impl TagsLeafNode {
             if offset + need > slice_len {
                 let key_number = i + 1;
                 let shortfall = offset + need - slice_len;
-                return Err(DdbError::DeserializationError(format!(
+                return Err(DcbError::DeserializationError(format!(
                     "Unexpected end of data while reading tags leaf value positions for key {key_number}/{keys_len}: shortfall: {shortfall}, slice len: {slice_len}, offset: {offset}, need: {need}"
                 )));
             }
@@ -173,11 +173,11 @@ impl TagsLeafNode {
         let last_key = self
             .keys
             .pop()
-            .ok_or_else(|| DdbError::DeserializationError("No keys to pop".to_string()))?;
+            .ok_or_else(|| DcbError::DeserializationError("No keys to pop".to_string()))?;
         let last_value = self
             .values
             .pop()
-            .ok_or_else(|| DdbError::DeserializationError("No values to pop".to_string()))?;
+            .ok_or_else(|| DcbError::DeserializationError("No values to pop".to_string()))?;
         Ok((last_key, last_value))
     }
 }
@@ -218,7 +218,7 @@ impl TagsInternalNode {
 
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -227,7 +227,7 @@ impl TagsInternalNode {
         let keyw = get_tag_key_width();
         let keys_bytes = 2 + keys_len * keyw;
         if slice.len() < keys_bytes {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 keys_bytes,
                 slice.len()
@@ -244,7 +244,7 @@ impl TagsInternalNode {
         let child_ids_len = keys_len + 1;
         let need = child_ids_len * 8;
         if slice.len() < keys_bytes + need {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for child_ids, got {}",
                 keys_bytes + need,
                 slice.len()
@@ -266,7 +266,7 @@ impl TagsInternalNode {
             self.child_ids[last_idx] = new_id;
             Ok(())
         } else {
-            Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()))
+            Err(DcbError::DatabaseCorrupted("Child ID mismatch".to_string()))
         }
     }
 
@@ -285,7 +285,7 @@ impl TagsInternalNode {
         // Promote the separator key which is the minimum key of the new right subtree.
         let total_children = self.child_ids.len();
         if total_children < 4 || self.keys.len() + 1 != total_children {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Cannot split internal node with insufficient arity".to_string(),
             ));
         }
@@ -330,7 +330,7 @@ impl TagLeafNode {
 
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -339,7 +339,7 @@ impl TagLeafNode {
         let positions_len = LittleEndian::read_u16(&slice[0..2]) as usize;
         let need = positions_len * 8;
         if slice.len() < 2 + need {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for positions, got {}",
                 2 + need,
                 slice.len()
@@ -357,7 +357,7 @@ impl TagLeafNode {
     pub fn pop_last_position(&mut self) -> DcbResult<Position> {
         self.positions
             .pop()
-            .ok_or_else(|| DdbError::DeserializationError("No positions to pop".to_string()))
+            .ok_or_else(|| DcbError::DeserializationError("No positions to pop".to_string()))
     }
 }
 
@@ -392,7 +392,7 @@ impl TagInternalNode {
 
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -400,7 +400,7 @@ impl TagInternalNode {
         let keys_len = LittleEndian::read_u16(&slice[0..2]) as usize;
         let keys_bytes = 2 + keys_len * 8;
         if slice.len() < keys_bytes {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 keys_bytes,
                 slice.len()
@@ -416,7 +416,7 @@ impl TagInternalNode {
         let child_ids_len = keys_len + 1;
         let need = child_ids_len * 8;
         if slice.len() < keys_bytes + need {
-            return Err(DdbError::DeserializationError(format!(
+            return Err(DcbError::DeserializationError(format!(
                 "Expected at least {} bytes for child_ids, got {}",
                 keys_bytes + need,
                 slice.len()
@@ -596,7 +596,7 @@ impl TagInternalNode {
         // Promote the separator key which is the minimum key of the new right subtree.
         let total_children = self.child_ids.len();
         if total_children < 4 || self.keys.len() + 1 != total_children {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Cannot split internal node with insufficient arity".to_string(),
             ));
         }

--- a/umadb-core/src/tags_tree_nodes.rs
+++ b/umadb-core/src/tags_tree_nodes.rs
@@ -1,7 +1,7 @@
 use crate::common::{PageID, Position};
 use byteorder::{ByteOrder, LittleEndian};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use umadb_dcb::{DCBError, DCBResult};
+use umadb_dcb::{DdbError, DcbResult};
 
 /// Length in bytes of the hashed tag key used in-memory for TagHash
 pub const TAG_HASH_LEN: usize = 16;
@@ -95,10 +95,10 @@ impl TagsLeafNode {
         i
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         let slice_len = slice.len();
         if slice_len < 2 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice_len
             )));
@@ -111,7 +111,7 @@ impl TagsLeafNode {
         let keyw = get_tag_key_width();
         let keys_bytes = 2 + keys_len * keyw;
         if slice_len < keys_bytes {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 keys_bytes, slice_len
             )));
@@ -134,7 +134,7 @@ impl TagsLeafNode {
             if offset + need > slice_len {
                 let key_number = i + 1;
                 let shortfall = offset + need - slice_len;
-                return Err(DCBError::DeserializationError(format!(
+                return Err(DdbError::DeserializationError(format!(
                     "Unexpected end of data while reading tags leaf value header for key {key_number}/{keys_len}: shortfall: {shortfall}, slice len: {slice_len}, offset: {offset}, need: {need}"
                 )));
             }
@@ -151,7 +151,7 @@ impl TagsLeafNode {
             if offset + need > slice_len {
                 let key_number = i + 1;
                 let shortfall = offset + need - slice_len;
-                return Err(DCBError::DeserializationError(format!(
+                return Err(DdbError::DeserializationError(format!(
                     "Unexpected end of data while reading tags leaf value positions for key {key_number}/{keys_len}: shortfall: {shortfall}, slice len: {slice_len}, offset: {offset}, need: {need}"
                 )));
             }
@@ -169,15 +169,15 @@ impl TagsLeafNode {
         Ok(TagsLeafNode { keys, values })
     }
 
-    pub fn pop_last_key_and_value(&mut self) -> DCBResult<(TagHash, TagsLeafValue)> {
+    pub fn pop_last_key_and_value(&mut self) -> DcbResult<(TagHash, TagsLeafValue)> {
         let last_key = self
             .keys
             .pop()
-            .ok_or_else(|| DCBError::DeserializationError("No keys to pop".to_string()))?;
+            .ok_or_else(|| DdbError::DeserializationError("No keys to pop".to_string()))?;
         let last_value = self
             .values
             .pop()
-            .ok_or_else(|| DCBError::DeserializationError("No values to pop".to_string()))?;
+            .ok_or_else(|| DdbError::DeserializationError("No values to pop".to_string()))?;
         Ok((last_key, last_value))
     }
 }
@@ -216,9 +216,9 @@ impl TagsInternalNode {
         i
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -227,7 +227,7 @@ impl TagsInternalNode {
         let keyw = get_tag_key_width();
         let keys_bytes = 2 + keys_len * keyw;
         if slice.len() < keys_bytes {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 keys_bytes,
                 slice.len()
@@ -244,7 +244,7 @@ impl TagsInternalNode {
         let child_ids_len = keys_len + 1;
         let need = child_ids_len * 8;
         if slice.len() < keys_bytes + need {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for child_ids, got {}",
                 keys_bytes + need,
                 slice.len()
@@ -260,13 +260,13 @@ impl TagsInternalNode {
         Ok(TagsInternalNode { keys, child_ids })
     }
 
-    pub fn replace_last_child_id(&mut self, old_id: PageID, new_id: PageID) -> DCBResult<()> {
+    pub fn replace_last_child_id(&mut self, old_id: PageID, new_id: PageID) -> DcbResult<()> {
         let last_idx = self.child_ids.len() - 1;
         if self.child_ids[last_idx] == old_id {
             self.child_ids[last_idx] = new_id;
             Ok(())
         } else {
-            Err(DCBError::DatabaseCorrupted("Child ID mismatch".to_string()))
+            Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()))
         }
     }
 
@@ -274,18 +274,18 @@ impl TagsInternalNode {
         &mut self,
         promoted_key: TagHash,
         promoted_page_id: PageID,
-    ) -> DCBResult<()> {
+    ) -> DcbResult<()> {
         self.keys.push(promoted_key);
         self.child_ids.push(promoted_page_id);
         Ok(())
     }
 
-    pub(crate) fn split_off(&mut self) -> DCBResult<(TagHash, Vec<TagHash>, Vec<PageID>)> {
+    pub(crate) fn split_off(&mut self) -> DcbResult<(TagHash, Vec<TagHash>, Vec<PageID>)> {
         // Split by moving half of the child_ids to a new node.
         // Promote the separator key which is the minimum key of the new right subtree.
         let total_children = self.child_ids.len();
         if total_children < 4 || self.keys.len() + 1 != total_children {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Cannot split internal node with insufficient arity".to_string(),
             ));
         }
@@ -328,9 +328,9 @@ impl TagLeafNode {
         i
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -339,7 +339,7 @@ impl TagLeafNode {
         let positions_len = LittleEndian::read_u16(&slice[0..2]) as usize;
         let need = positions_len * 8;
         if slice.len() < 2 + need {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for positions, got {}",
                 2 + need,
                 slice.len()
@@ -354,10 +354,10 @@ impl TagLeafNode {
         Ok(TagLeafNode { positions })
     }
 
-    pub fn pop_last_position(&mut self) -> DCBResult<Position> {
+    pub fn pop_last_position(&mut self) -> DcbResult<Position> {
         self.positions
             .pop()
-            .ok_or_else(|| DCBError::DeserializationError("No positions to pop".to_string()))
+            .ok_or_else(|| DdbError::DeserializationError("No positions to pop".to_string()))
     }
 }
 
@@ -390,9 +390,9 @@ impl TagInternalNode {
         i
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.len() < 2 {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least 2 bytes, got {}",
                 slice.len()
             )));
@@ -400,7 +400,7 @@ impl TagInternalNode {
         let keys_len = LittleEndian::read_u16(&slice[0..2]) as usize;
         let keys_bytes = 2 + keys_len * 8;
         if slice.len() < keys_bytes {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for keys, got {}",
                 keys_bytes,
                 slice.len()
@@ -416,7 +416,7 @@ impl TagInternalNode {
         let child_ids_len = keys_len + 1;
         let need = child_ids_len * 8;
         if slice.len() < keys_bytes + need {
-            return Err(DCBError::DeserializationError(format!(
+            return Err(DdbError::DeserializationError(format!(
                 "Expected at least {} bytes for child_ids, got {}",
                 keys_bytes + need,
                 slice.len()
@@ -591,12 +591,12 @@ mod tests {
 }
 
 impl TagInternalNode {
-    pub(crate) fn split_off(&mut self) -> DCBResult<(Position, Vec<Position>, Vec<PageID>)> {
+    pub(crate) fn split_off(&mut self) -> DcbResult<(Position, Vec<Position>, Vec<PageID>)> {
         // Split by moving half of the child_ids to a new node.
         // Promote the separator key which is the minimum key of the new right subtree.
         let total_children = self.child_ids.len();
         if total_children < 4 || self.keys.len() + 1 != total_children {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Cannot split internal node with insufficient arity".to_string(),
             ));
         }

--- a/umadb-core/src/tracking_tree_nodes.rs
+++ b/umadb-core/src/tracking_tree_nodes.rs
@@ -1,6 +1,6 @@
 use crate::common::{PageID, Position};
 use byteorder::{ByteOrder, LittleEndian};
-use umadb_dcb::{DdbError, DcbResult};
+use umadb_dcb::{DcbError, DcbResult};
 
 /// A simple leaf-only node for the tracking tree.
 /// Keys are UTF-8 source strings; values are positions.
@@ -60,27 +60,27 @@ impl TrackingLeafNode {
 
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.is_empty() {
-            return Err(DdbError::DeserializationError(
+            return Err(DcbError::DeserializationError(
                 "tracking leaf too small".to_string(),
             ));
         }
         let ver = slice[0];
         let (mut off, count): (usize, usize) = if ver == 0 {
             if slice.len() < 5 {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "tracking leaf too small (v0)".to_string(),
                 ));
             }
             let cnt_u32 = LittleEndian::read_u32(&slice[1..5]);
             if cnt_u32 > u16::MAX as u32 {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "v0 tracking leaf count exceeds u16".to_string(),
                 ));
             }
             (5, cnt_u32 as usize)
         } else {
             if slice.len() < 3 {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "tracking leaf too small (v1)".to_string(),
                 ));
             }
@@ -90,43 +90,43 @@ impl TrackingLeafNode {
         for _ in 0..count {
             if ver == 0 {
                 if off + 4 > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "tracking leaf truncated klen (v0)".to_string(),
                     ));
                 }
                 let klen_u32 = LittleEndian::read_u32(&slice[off..off + 4]);
                 if klen_u32 > u8::MAX as u32 {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "v0 tracking leaf key length exceeds u8".to_string(),
                     ));
                 }
                 let klen = klen_u32 as usize;
                 off += 4;
                 if off + klen > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "tracking leaf truncated key (v0)".to_string(),
                     ));
                 }
                 let k = std::str::from_utf8(&slice[off..off + klen])
-                    .map_err(|e| DdbError::DeserializationError(format!("invalid utf8: {e}")))?
+                    .map_err(|e| DcbError::DeserializationError(format!("invalid utf8: {e}")))?
                     .to_string();
                 off += klen;
                 keys.push(k);
             } else {
                 if off + 1 > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "tracking leaf truncated klen (v1)".to_string(),
                     ));
                 }
                 let klen = slice[off] as usize;
                 off += 1;
                 if off + klen > slice.len() {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "tracking leaf truncated key (v1)".to_string(),
                     ));
                 }
                 let k = std::str::from_utf8(&slice[off..off + klen])
-                    .map_err(|e| DdbError::DeserializationError(format!("invalid utf8: {e}")))?
+                    .map_err(|e| DcbError::DeserializationError(format!("invalid utf8: {e}")))?
                     .to_string();
                 off += klen;
                 keys.push(k);
@@ -135,7 +135,7 @@ impl TrackingLeafNode {
         let mut values = Vec::with_capacity(count);
         for _ in 0..count {
             if off + 8 > slice.len() {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "tracking leaf truncated value".to_string(),
                 ));
             }
@@ -186,7 +186,7 @@ impl TrackingLeafNode {
                 let additional = key_len + 8;
                 let current = self.calc_serialized_size();
                 if current + additional > page_body_capacity {
-                    return Err(DdbError::InternalError(
+                    return Err(DcbError::InternalError(
                         "not implemented: tracking split".to_string(),
                     ));
                 }
@@ -219,12 +219,12 @@ impl TrackingInternalNode {
         new_id: PageID,
     ) -> DcbResult<()> {
         if idx >= self.child_ids.len() {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "child index out of bounds".to_string(),
             ));
         }
         if self.child_ids[idx] != old_id {
-            return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
+            return Err(DcbError::DatabaseCorrupted("Child ID mismatch".to_string()));
         }
         self.child_ids[idx] = new_id;
         Ok(())
@@ -238,7 +238,7 @@ impl TrackingInternalNode {
     /// Split this internal node around the middle key. Returns (promoted_key, right_keys, right_child_ids).
     pub fn split_off(&mut self) -> DcbResult<(String, Vec<String>, Vec<PageID>)> {
         if self.child_ids.len() < 4 || self.keys.len() + 1 != self.child_ids.len() {
-            return Err(DdbError::DatabaseCorrupted(
+            return Err(DcbError::DatabaseCorrupted(
                 "Cannot split tracking internal with insufficient arity".to_string(),
             ));
         }
@@ -303,18 +303,18 @@ impl TrackingInternalNode {
 
     pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.is_empty() {
-            return Err(DdbError::DeserializationError(
+            return Err(DcbError::DeserializationError(
                 "tracking internal too small".to_string(),
             ));
         }
         let ver = slice[0];
         if ver == 0 {
-            return Err(DdbError::DeserializationError(
+            return Err(DcbError::DeserializationError(
                 "unsupported tracking internal version 0".to_string(),
             ));
         }
         if slice.len() < 3 {
-            return Err(DdbError::DeserializationError(
+            return Err(DcbError::DeserializationError(
                 "tracking internal too small (v1)".to_string(),
             ));
         }
@@ -323,19 +323,19 @@ impl TrackingInternalNode {
         let mut keys = Vec::with_capacity(count);
         for _ in 0..count {
             if off + 1 > slice.len() {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "tracking internal truncated klen (v1)".to_string(),
                 ));
             }
             let klen = slice[off] as usize;
             off += 1;
             if off + klen > slice.len() {
-                return Err(DdbError::DeserializationError(
+                return Err(DcbError::DeserializationError(
                     "tracking internal truncated key (v1)".to_string(),
                 ));
             }
             let k = std::str::from_utf8(&slice[off..off + klen])
-                .map_err(|e| DdbError::DeserializationError(format!("invalid utf8: {e}")))?
+                .map_err(|e| DcbError::DeserializationError(format!("invalid utf8: {e}")))?
                 .to_string();
             off += klen;
             keys.push(k);
@@ -344,7 +344,7 @@ impl TrackingInternalNode {
         let child_count = keys.len() + 1;
         let need = off + 8 * child_count;
         if slice.len() < need {
-            return Err(DdbError::DeserializationError(
+            return Err(DcbError::DeserializationError(
                 "tracking internal truncated children".to_string(),
             ));
         }
@@ -432,7 +432,7 @@ mod tests {
             .upsert_no_split("x", Position(9), small_capacity)
             .unwrap_err();
         match err {
-            DdbError::InternalError(s) => assert!(s.contains("tracking split")),
+            DcbError::InternalError(s) => assert!(s.contains("tracking split")),
             _ => panic!("unexpected error type"),
         }
     }
@@ -475,7 +475,7 @@ mod tests {
         buf.truncate(buf.len() - 4); // remove less than 8 to force error path
         let err = TrackingInternalNode::from_slice(&buf).unwrap_err();
         match err {
-            DdbError::DeserializationError(_) => {}
+            DcbError::DeserializationError(_) => {}
             _ => panic!("expected DeserializationError"),
         }
     }

--- a/umadb-core/src/tracking_tree_nodes.rs
+++ b/umadb-core/src/tracking_tree_nodes.rs
@@ -1,6 +1,6 @@
 use crate::common::{PageID, Position};
 use byteorder::{ByteOrder, LittleEndian};
-use umadb_dcb::{DCBError, DCBResult};
+use umadb_dcb::{DdbError, DcbResult};
 
 /// A simple leaf-only node for the tracking tree.
 /// Keys are UTF-8 source strings; values are positions.
@@ -58,29 +58,29 @@ impl TrackingLeafNode {
         needed
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.is_empty() {
-            return Err(DCBError::DeserializationError(
+            return Err(DdbError::DeserializationError(
                 "tracking leaf too small".to_string(),
             ));
         }
         let ver = slice[0];
         let (mut off, count): (usize, usize) = if ver == 0 {
             if slice.len() < 5 {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "tracking leaf too small (v0)".to_string(),
                 ));
             }
             let cnt_u32 = LittleEndian::read_u32(&slice[1..5]);
             if cnt_u32 > u16::MAX as u32 {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "v0 tracking leaf count exceeds u16".to_string(),
                 ));
             }
             (5, cnt_u32 as usize)
         } else {
             if slice.len() < 3 {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "tracking leaf too small (v1)".to_string(),
                 ));
             }
@@ -90,43 +90,43 @@ impl TrackingLeafNode {
         for _ in 0..count {
             if ver == 0 {
                 if off + 4 > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "tracking leaf truncated klen (v0)".to_string(),
                     ));
                 }
                 let klen_u32 = LittleEndian::read_u32(&slice[off..off + 4]);
                 if klen_u32 > u8::MAX as u32 {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "v0 tracking leaf key length exceeds u8".to_string(),
                     ));
                 }
                 let klen = klen_u32 as usize;
                 off += 4;
                 if off + klen > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "tracking leaf truncated key (v0)".to_string(),
                     ));
                 }
                 let k = std::str::from_utf8(&slice[off..off + klen])
-                    .map_err(|e| DCBError::DeserializationError(format!("invalid utf8: {e}")))?
+                    .map_err(|e| DdbError::DeserializationError(format!("invalid utf8: {e}")))?
                     .to_string();
                 off += klen;
                 keys.push(k);
             } else {
                 if off + 1 > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "tracking leaf truncated klen (v1)".to_string(),
                     ));
                 }
                 let klen = slice[off] as usize;
                 off += 1;
                 if off + klen > slice.len() {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "tracking leaf truncated key (v1)".to_string(),
                     ));
                 }
                 let k = std::str::from_utf8(&slice[off..off + klen])
-                    .map_err(|e| DCBError::DeserializationError(format!("invalid utf8: {e}")))?
+                    .map_err(|e| DdbError::DeserializationError(format!("invalid utf8: {e}")))?
                     .to_string();
                 off += klen;
                 keys.push(k);
@@ -135,7 +135,7 @@ impl TrackingLeafNode {
         let mut values = Vec::with_capacity(count);
         for _ in 0..count {
             if off + 8 > slice.len() {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "tracking leaf truncated value".to_string(),
                 ));
             }
@@ -172,7 +172,7 @@ impl TrackingLeafNode {
         source: &str,
         pos: Position,
         page_body_capacity: usize,
-    ) -> DCBResult<()> {
+    ) -> DcbResult<()> {
         match self.keys.binary_search_by(|k| k.as_str().cmp(source)) {
             Ok(idx) => {
                 // Key exists; update value in place
@@ -186,7 +186,7 @@ impl TrackingLeafNode {
                 let additional = key_len + 8;
                 let current = self.calc_serialized_size();
                 if current + additional > page_body_capacity {
-                    return Err(DCBError::InternalError(
+                    return Err(DdbError::InternalError(
                         "not implemented: tracking split".to_string(),
                     ));
                 }
@@ -217,14 +217,14 @@ impl TrackingInternalNode {
         idx: usize,
         old_id: PageID,
         new_id: PageID,
-    ) -> DCBResult<()> {
+    ) -> DcbResult<()> {
         if idx >= self.child_ids.len() {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "child index out of bounds".to_string(),
             ));
         }
         if self.child_ids[idx] != old_id {
-            return Err(DCBError::DatabaseCorrupted("Child ID mismatch".to_string()));
+            return Err(DdbError::DatabaseCorrupted("Child ID mismatch".to_string()));
         }
         self.child_ids[idx] = new_id;
         Ok(())
@@ -236,9 +236,9 @@ impl TrackingInternalNode {
     }
 
     /// Split this internal node around the middle key. Returns (promoted_key, right_keys, right_child_ids).
-    pub fn split_off(&mut self) -> DCBResult<(String, Vec<String>, Vec<PageID>)> {
+    pub fn split_off(&mut self) -> DcbResult<(String, Vec<String>, Vec<PageID>)> {
         if self.child_ids.len() < 4 || self.keys.len() + 1 != self.child_ids.len() {
-            return Err(DCBError::DatabaseCorrupted(
+            return Err(DdbError::DatabaseCorrupted(
                 "Cannot split tracking internal with insufficient arity".to_string(),
             ));
         }
@@ -301,20 +301,20 @@ impl TrackingInternalNode {
         needed
     }
 
-    pub fn from_slice(slice: &[u8]) -> DCBResult<Self> {
+    pub fn from_slice(slice: &[u8]) -> DcbResult<Self> {
         if slice.is_empty() {
-            return Err(DCBError::DeserializationError(
+            return Err(DdbError::DeserializationError(
                 "tracking internal too small".to_string(),
             ));
         }
         let ver = slice[0];
         if ver == 0 {
-            return Err(DCBError::DeserializationError(
+            return Err(DdbError::DeserializationError(
                 "unsupported tracking internal version 0".to_string(),
             ));
         }
         if slice.len() < 3 {
-            return Err(DCBError::DeserializationError(
+            return Err(DdbError::DeserializationError(
                 "tracking internal too small (v1)".to_string(),
             ));
         }
@@ -323,19 +323,19 @@ impl TrackingInternalNode {
         let mut keys = Vec::with_capacity(count);
         for _ in 0..count {
             if off + 1 > slice.len() {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "tracking internal truncated klen (v1)".to_string(),
                 ));
             }
             let klen = slice[off] as usize;
             off += 1;
             if off + klen > slice.len() {
-                return Err(DCBError::DeserializationError(
+                return Err(DdbError::DeserializationError(
                     "tracking internal truncated key (v1)".to_string(),
                 ));
             }
             let k = std::str::from_utf8(&slice[off..off + klen])
-                .map_err(|e| DCBError::DeserializationError(format!("invalid utf8: {e}")))?
+                .map_err(|e| DdbError::DeserializationError(format!("invalid utf8: {e}")))?
                 .to_string();
             off += klen;
             keys.push(k);
@@ -344,7 +344,7 @@ impl TrackingInternalNode {
         let child_count = keys.len() + 1;
         let need = off + 8 * child_count;
         if slice.len() < need {
-            return Err(DCBError::DeserializationError(
+            return Err(DdbError::DeserializationError(
                 "tracking internal truncated children".to_string(),
             ));
         }
@@ -432,7 +432,7 @@ mod tests {
             .upsert_no_split("x", Position(9), small_capacity)
             .unwrap_err();
         match err {
-            DCBError::InternalError(s) => assert!(s.contains("tracking split")),
+            DdbError::InternalError(s) => assert!(s.contains("tracking split")),
             _ => panic!("unexpected error type"),
         }
     }
@@ -475,7 +475,7 @@ mod tests {
         buf.truncate(buf.len() - 4); // remove less than 8 to force error path
         let err = TrackingInternalNode::from_slice(&buf).unwrap_err();
         match err {
-            DCBError::DeserializationError(_) => {}
+            DdbError::DeserializationError(_) => {}
             _ => panic!("expected DeserializationError"),
         }
     }

--- a/umadb-core/tests/tracking_append_batch_tests.rs
+++ b/umadb-core/tests/tracking_append_batch_tests.rs
@@ -1,7 +1,7 @@
 use serial_test::serial;
 use tempfile::tempdir;
 use umadb_core::db::UmaDB;
-use umadb_dcb::{DCBAppendCondition, DCBEvent, DCBEventStoreSync, TrackingInfo};
+use umadb_dcb::{DcbAppendCondition, DcbEvent, DcbEventStoreSync, TrackingInfo};
 
 #[test]
 #[serial]
@@ -11,7 +11,7 @@ fn append_batch_with_per_item_tracking_enforces_monotonicity() {
     let store = UmaDB::new(&db_path).unwrap();
 
     // simple helper to make an event
-    let mk = |t: &str| DCBEvent {
+    let mk = |t: &str| DcbEvent {
         event_type: t.to_string(),
         data: b"x".to_vec(),
         tags: vec!["t".into()],
@@ -25,7 +25,7 @@ fn append_batch_with_per_item_tracking_enforces_monotonicity() {
     let items = vec![
         (
             vec![mk("A1")],
-            None::<DCBAppendCondition>,
+            None::<DcbAppendCondition>,
             Some(TrackingInfo {
                 source: "S".into(),
                 position: 5,
@@ -59,7 +59,7 @@ fn append_batch_with_per_item_tracking_enforces_monotonicity() {
     }
     // 2) Err(IntegrityError)
     match &results[1] {
-        Err(e) => assert!(matches!(e, umadb_dcb::DCBError::IntegrityError(_))),
+        Err(e) => assert!(matches!(e, umadb_dcb::DdbError::IntegrityError(_))),
         other => panic!("expected IntegrityError, got {:?}", other),
     }
     // 3) Ok(last = 2)

--- a/umadb-core/tests/tracking_append_batch_tests.rs
+++ b/umadb-core/tests/tracking_append_batch_tests.rs
@@ -59,7 +59,7 @@ fn append_batch_with_per_item_tracking_enforces_monotonicity() {
     }
     // 2) Err(IntegrityError)
     match &results[1] {
-        Err(e) => assert!(matches!(e, umadb_dcb::DdbError::IntegrityError(_))),
+        Err(e) => assert!(matches!(e, umadb_dcb::DcbError::IntegrityError(_))),
         other => panic!("expected IntegrityError, got {:?}", other),
     }
     // 3) Ok(last = 2)

--- a/umadb-dcb/src/lib.rs
+++ b/umadb-dcb/src/lib.rs
@@ -339,7 +339,7 @@ pub struct DcbSequencedEvent {
 // Error types
 #[derive(Error, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum DdbError {
+pub enum DcbError {
     // Generic/system errors
     #[error("io error: {0}")]
     #[cfg_attr(feature = "serde", serde(with = "serde_io_error"))]
@@ -385,7 +385,7 @@ pub enum DdbError {
     AuthenticationError(String),
 }
 
-pub type DcbResult<T> = Result<T, DdbError>;
+pub type DcbResult<T> = Result<T, DcbError>;
 
 #[cfg(feature = "serde")]
 mod serde_io_error {

--- a/umadb-dcb/src/lib.rs
+++ b/umadb-dcb/src/lib.rs
@@ -341,47 +341,47 @@ pub struct DCBSequencedEvent {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DCBError {
     // Generic/system errors
-    #[error("IO error: {0}")]
+    #[error("io error: {0}")]
     #[cfg_attr(feature = "serde", serde(with = "serde_io_error"))]
     Io(#[from] std::io::Error),
 
     // DCB domain errors
-    #[error("Integrity error: condition failed: {0}")]
+    #[error("integrity error: condition failed: {0}")]
     IntegrityError(String),
-    #[error("Corruption detected: {0}")]
+    #[error("corruption detected: {0}")]
     Corruption(String),
     /// Invalid input argument provided by the caller
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
 
     // Storage errors (unified into DCBError)
-    #[error("Initialization error: {0:?}")]
+    #[error("initialization error: {0}")]
     InitializationError(String),
-    #[error("Page not found: {0:?}")]
+    #[error("page not found: {0}")]
     PageNotFound(u64),
-    #[error("Dirty page not found: {0:?}")]
+    #[error("dirty page not found: {0}")]
     DirtyPageNotFound(u64),
-    #[error("Root ID mismatched: old {0:?} new {1:?}")]
+    #[error("root ID mismatched: old {0} new {1}")]
     RootIDMismatch(u64, u64),
-    #[error("Database corrupted: {0}")]
+    #[error("database corrupted: {0}")]
     DatabaseCorrupted(String),
-    #[error("Internal error: {0}")]
+    #[error("internal error: {0}")]
     InternalError(String),
-    #[error("Serialization error: {0}")]
+    #[error("serialization error: {0}")]
     SerializationError(String),
-    #[error("Deserialization error: {0}")]
+    #[error("deserialization error: {0}")]
     DeserializationError(String),
-    #[error("Page already freed: {0:?}")]
+    #[error("page already freed: {0}")]
     PageAlreadyFreed(u64),
-    #[error("Page already dirty: {0:?}")]
+    #[error("page already dirty: {0}")]
     PageAlreadyDirty(u64),
-    #[error("Transport error: {0}")]
+    #[error("transport error: {0}")]
     TransportError(String),
-    #[error("Cancelled by user")]
+    #[error("cancelled by user")]
     CancelledByUser(),
 
     // Authentication error
-    #[error("Authentication error: {0}")]
+    #[error("authentication error: {0}")]
     AuthenticationError(String),
 }
 

--- a/umadb-dcb/src/lib.rs
+++ b/umadb-dcb/src/lib.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 /// Non-async Rust interface for recording and retrieving events
-pub trait DCBEventStoreSync {
+pub trait DcbEventStoreSync {
     /// Reads events from the store based on the provided query and constraints
     ///
     /// Returns a DCBReadResponseSync that provides an iterator over all events,
@@ -21,21 +21,21 @@ pub trait DCBEventStoreSync {
     /// there are no item types, and if all the item tags are in the event tags.
     fn read(
         &self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         start: Option<u64>,
         backwards: bool,
         limit: Option<u32>,
         subscribe: bool, // Deprecated - remove in v1.0.
-    ) -> DCBResult<Box<dyn DCBReadResponseSync + Send + 'static>>;
+    ) -> DcbResult<Box<dyn DcbReadResponseSync + Send + 'static>>;
 
     /// Reads events from the store and returns them as a tuple of (Vec<DCBSequencedEvent>, Option<u64>)
     fn read_with_head(
         &self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         start: Option<u64>,
         backwards: bool,
         limit: Option<u32>,
-    ) -> DCBResult<(Vec<DCBSequencedEvent>, Option<u64>)> {
+    ) -> DcbResult<(Vec<DcbSequencedEvent>, Option<u64>)> {
         let mut response = self.read(query, start, backwards, limit, false)?;
         response.collect_with_head()
     }
@@ -43,46 +43,46 @@ pub trait DCBEventStoreSync {
     /// Returns the current head position of the event store, or None if empty
     ///
     /// Returns the value of last_committed_position, or None if last_committed_position is zero
-    fn head(&self) -> DCBResult<Option<u64>>;
+    fn head(&self) -> DcbResult<Option<u64>>;
 
     /// Returns the greatest recorded upstream position for a tracking source, if any
-    fn get_tracking_info(&self, source: &str) -> DCBResult<Option<u64>>;
+    fn get_tracking_info(&self, source: &str) -> DcbResult<Option<u64>>;
 
     /// Appends given events to the event store, unless the condition fails
     ///
     /// Returns the position of the last appended event
     fn append(
         &self,
-        events: Vec<DCBEvent>,
-        condition: Option<DCBAppendCondition>,
+        events: Vec<DcbEvent>,
+        condition: Option<DcbAppendCondition>,
         tracking_info: Option<TrackingInfo>,
-    ) -> DCBResult<u64>;
+    ) -> DcbResult<u64>;
 }
 
 /// Response from a read operation, providing an iterator over sequenced events
-pub trait DCBReadResponseSync: Iterator<Item = DCBResult<DCBSequencedEvent>> + Send {
+pub trait DcbReadResponseSync: Iterator<Item = DcbResult<DcbSequencedEvent>> + Send {
     /// Returns the current head position of the event store, or None if empty
-    fn head(&mut self) -> DCBResult<Option<u64>>;
+    fn head(&mut self) -> DcbResult<Option<u64>>;
     /// Returns a vector of events with head
-    fn collect_with_head(&mut self) -> DCBResult<(Vec<DCBSequencedEvent>, Option<u64>)>;
+    fn collect_with_head(&mut self) -> DcbResult<(Vec<DcbSequencedEvent>, Option<u64>)>;
     /// Returns the next batch of events for this read. Implementations may buffer
     /// events per underlying transport message ("batch"). If there are no more
     /// events available, returns an empty Vec. The head() method should reflect
     /// the latest known head as reported by the underlying store.
-    fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>>;
+    fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>>;
 }
 
 /// Response from a subscribe operation, providing an iterator over sequenced events
-pub trait DCBSubscriptionSync: Iterator<Item = DCBResult<DCBSequencedEvent>> + Send {
+pub trait DcbSubscriptionSync: Iterator<Item = DcbResult<DcbSequencedEvent>> + Send {
     /// Returns the next batch of events for this read. Implementations may buffer
     /// events per underlying transport message ("batch"). If there are no more
     /// events available, returns an empty Vec.
-    fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>>;
+    fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>>;
 }
 
 /// Async Rust interface for recording and retrieving events
 #[async_trait]
-pub trait DCBEventStoreAsync: Send + Sync {
+pub trait DcbEventStoreAsync: Send + Sync {
     /// Reads events from the store based on the provided query and constraints
     ///
     /// Returns a DCBReadResponseSync that provides an iterator over all events,
@@ -92,21 +92,21 @@ pub trait DCBEventStoreAsync: Send + Sync {
     /// there are no item types, and if all the item tags are in the event tags.
     async fn read<'a>(
         &'a self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         start: Option<u64>,
         backwards: bool,
         limit: Option<u32>,
         subscribe: bool,
-    ) -> DCBResult<Box<dyn DCBReadResponseAsync + Send + 'static>>;
+    ) -> DcbResult<Box<dyn DcbReadResponseAsync + Send + 'static>>;
 
     /// Reads events from the store and returns them as a tuple of (Vec<DCBSequencedEvent>, Option<u64>)
     async fn read_with_head<'a>(
         &'a self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         after: Option<u64>,
         backwards: bool,
         limit: Option<u32>,
-    ) -> DCBResult<(Vec<DCBSequencedEvent>, Option<u64>)> {
+    ) -> DcbResult<(Vec<DcbSequencedEvent>, Option<u64>)> {
         let mut response = self.read(query, after, backwards, limit, false).await?;
         response.collect_with_head().await
     }
@@ -114,28 +114,28 @@ pub trait DCBEventStoreAsync: Send + Sync {
     /// Returns the current head position of the event store, or None if empty
     ///
     /// Returns the value of last_committed_position, or None if last_committed_position is zero
-    async fn head(&self) -> DCBResult<Option<u64>>;
+    async fn head(&self) -> DcbResult<Option<u64>>;
 
     /// Returns the greatest recorded upstream position for a tracking source, if any
-    async fn get_tracking_info(&self, source: &str) -> DCBResult<Option<u64>>;
+    async fn get_tracking_info(&self, source: &str) -> DcbResult<Option<u64>>;
 
     /// Appends given events to the event store, unless the condition fails
     ///
     /// Returns the position of the last appended event
     async fn append(
         &self,
-        events: Vec<DCBEvent>,
-        condition: Option<DCBAppendCondition>,
+        events: Vec<DcbEvent>,
+        condition: Option<DcbAppendCondition>,
         tracking_info: Option<TrackingInfo>,
-    ) -> DCBResult<u64>;
+    ) -> DcbResult<u64>;
 }
 
 /// Asynchronous response from a read operation, providing a stream of sequenced events
 #[async_trait]
-pub trait DCBReadResponseAsync: Stream<Item = DCBResult<DCBSequencedEvent>> + Send + Unpin {
-    async fn head(&mut self) -> DCBResult<Option<u64>>;
+pub trait DcbReadResponseAsync: Stream<Item = DcbResult<DcbSequencedEvent>> + Send + Unpin {
+    async fn head(&mut self) -> DcbResult<Option<u64>>;
 
-    async fn collect_with_head(&mut self) -> DCBResult<(Vec<DCBSequencedEvent>, Option<u64>)> {
+    async fn collect_with_head(&mut self) -> DcbResult<(Vec<DcbSequencedEvent>, Option<u64>)> {
         let mut events = Vec::new();
         while let Some(result) = self.next().await {
             events.push(result?); // propagate error from stream
@@ -145,26 +145,26 @@ pub trait DCBReadResponseAsync: Stream<Item = DCBResult<DCBSequencedEvent>> + Se
         Ok((events, head))
     }
 
-    async fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>>;
+    async fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>>;
 }
 
 /// Asynchronous response from a subscribe operation, providing a stream of sequenced events
 #[async_trait]
-pub trait DCBSubscriptionAsync: Stream<Item = DCBResult<DCBSequencedEvent>> + Send + Unpin {
-    async fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>>;
+pub trait DcbSubscriptionAsync: Stream<Item = DcbResult<DcbSequencedEvent>> + Send + Unpin {
+    async fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>>;
 }
 
 /// Represents a query item for filtering events
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct DCBQueryItem {
+pub struct DcbQueryItem {
     /// Event types to match
     pub types: Vec<String>,
     /// Tags that must all be present in the event
     pub tags: Vec<String>,
 }
 
-impl DCBQueryItem {
+impl DcbQueryItem {
     /// Creates a new query item
     pub fn new() -> Self {
         Self {
@@ -197,12 +197,12 @@ impl DCBQueryItem {
 /// A query composed of multiple query items
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct DCBQuery {
+pub struct DcbQuery {
     /// List of query items, where events matching any item are included in results
-    pub items: Vec<DCBQueryItem>,
+    pub items: Vec<DcbQueryItem>,
 }
 
-impl DCBQuery {
+impl DcbQuery {
     /// Creates a new empty query
     pub fn new() -> Self {
         Self { items: Vec::new() }
@@ -211,7 +211,7 @@ impl DCBQuery {
     /// Creates a query with the specified items
     pub fn with_items<I>(items: I) -> Self
     where
-        I: IntoIterator<Item = DCBQueryItem>,
+        I: IntoIterator<Item = DcbQueryItem>,
     {
         Self {
             items: items.into_iter().collect(),
@@ -219,7 +219,7 @@ impl DCBQuery {
     }
 
     /// Adds a query item to this query
-    pub fn item(mut self, item: DCBQueryItem) -> Self {
+    pub fn item(mut self, item: DcbQueryItem) -> Self {
         self.items.push(item);
         self
     }
@@ -227,7 +227,7 @@ impl DCBQuery {
     /// Adds multiple query items to this query
     pub fn items<I>(mut self, items: I) -> Self
     where
-        I: IntoIterator<Item = DCBQueryItem>,
+        I: IntoIterator<Item = DcbQueryItem>,
     {
         self.items.extend(items);
         self
@@ -237,16 +237,16 @@ impl DCBQuery {
 /// Conditions that must be satisfied for an append operation to succeed
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct DCBAppendCondition {
+pub struct DcbAppendCondition {
     /// Query that, if matching any events, will cause the append to fail
-    pub fail_if_events_match: DCBQuery,
+    pub fail_if_events_match: DcbQuery,
     /// Position after which to append; if None, append at the end
     pub after: Option<u64>,
 }
 
-impl DCBAppendCondition {
+impl DcbAppendCondition {
     /// Creates a new empty append condition
-    pub fn new(fail_if_events_match: DCBQuery) -> Self {
+    pub fn new(fail_if_events_match: DcbQuery) -> Self {
         Self {
             fail_if_events_match,
             after: None,
@@ -262,7 +262,7 @@ impl DCBAppendCondition {
 /// Represents an event in the event store
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct DCBEvent {
+pub struct DcbEvent {
     /// Type of the event
     pub event_type: String,
     /// Tags associated with the event
@@ -273,13 +273,13 @@ pub struct DCBEvent {
     pub uuid: Option<Uuid>,
 }
 
-impl Default for DCBEvent {
+impl Default for DcbEvent {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl DCBEvent {
+impl DcbEvent {
     /// Creates a new event
     pub fn new() -> Self {
         Self {
@@ -329,17 +329,17 @@ pub struct TrackingInfo {
 /// An event with its position in the event sequence
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct DCBSequencedEvent {
+pub struct DcbSequencedEvent {
     /// Position of the event in the sequence
     pub position: u64,
     /// The event
-    pub event: DCBEvent,
+    pub event: DcbEvent,
 }
 
 // Error types
 #[derive(Error, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum DCBError {
+pub enum DdbError {
     // Generic/system errors
     #[error("io error: {0}")]
     #[cfg_attr(feature = "serde", serde(with = "serde_io_error"))]
@@ -385,7 +385,7 @@ pub enum DCBError {
     AuthenticationError(String),
 }
 
-pub type DCBResult<T> = Result<T, DCBError>;
+pub type DcbResult<T> = Result<T, DdbError>;
 
 #[cfg(feature = "serde")]
 mod serde_io_error {
@@ -516,13 +516,13 @@ mod tests {
 
     // A simple implementation of DCBReadResponseSync for testing
     struct TestReadResponse {
-        events: Vec<DCBSequencedEvent>,
+        events: Vec<DcbSequencedEvent>,
         current_index: usize,
         head_position: Option<u64>,
     }
 
     impl TestReadResponse {
-        fn new(events: Vec<DCBSequencedEvent>, head_position: Option<u64>) -> Self {
+        fn new(events: Vec<DcbSequencedEvent>, head_position: Option<u64>) -> Self {
             Self {
                 events,
                 current_index: 0,
@@ -532,7 +532,7 @@ mod tests {
     }
 
     impl Iterator for TestReadResponse {
-        type Item = DCBResult<DCBSequencedEvent>;
+        type Item = DcbResult<DcbSequencedEvent>;
 
         fn next(&mut self) -> Option<Self::Item> {
             if self.current_index < self.events.len() {
@@ -545,16 +545,16 @@ mod tests {
         }
     }
 
-    impl DCBReadResponseSync for TestReadResponse {
-        fn head(&mut self) -> DCBResult<Option<u64>> {
+    impl DcbReadResponseSync for TestReadResponse {
+        fn head(&mut self) -> DcbResult<Option<u64>> {
             Ok(self.head_position)
         }
 
-        fn collect_with_head(&mut self) -> DCBResult<(Vec<DCBSequencedEvent>, Option<u64>)> {
+        fn collect_with_head(&mut self) -> DcbResult<(Vec<DcbSequencedEvent>, Option<u64>)> {
             todo!()
         }
 
-        fn next_batch(&mut self) -> DCBResult<Vec<DCBSequencedEvent>> {
+        fn next_batch(&mut self) -> DcbResult<Vec<DcbSequencedEvent>> {
             let mut batch = Vec::new();
             while let Some(result) = self.next() {
                 match result {
@@ -571,26 +571,26 @@ mod tests {
     #[test]
     fn test_dcb_read_response() {
         // Create some test events
-        let event1 = DCBEvent {
+        let event1 = DcbEvent {
             event_type: "test_event".to_string(),
             data: vec![1, 2, 3],
             tags: vec!["tag1".to_string(), "tag2".to_string()],
             uuid: None,
         };
 
-        let event2 = DCBEvent {
+        let event2 = DcbEvent {
             event_type: "another_event".to_string(),
             data: vec![4, 5, 6],
             tags: vec!["tag2".to_string(), "tag3".to_string()],
             uuid: None,
         };
 
-        let seq_event1 = DCBSequencedEvent {
+        let seq_event1 = DcbSequencedEvent {
             event: event1,
             position: 1,
         };
 
-        let seq_event2 = DCBSequencedEvent {
+        let seq_event2 = DcbSequencedEvent {
             event: event2,
             position: 2,
         };
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn test_event_new() {
-        let event1 = DCBEvent::default()
+        let event1 = DcbEvent::default()
             .event_type("type1")
             .data(b"data1")
             .tags(["tagX"]);
@@ -628,26 +628,26 @@ mod tests {
         assert_eq!(event1.uuid, None);
 
         // Test with multiple tags
-        let event2 = DCBEvent::default()
+        let event2 = DcbEvent::default()
             .event_type("type2")
             .data(b"data2")
             .tags(["tag1", "tag2", "tag3"]);
         assert_eq!(event2.tags.len(), 3);
 
         // Test without data or tags
-        let event3 = DCBEvent::default().event_type("type3");
+        let event3 = DcbEvent::default().event_type("type3");
         assert_eq!(event3.data.len(), 0);
         assert_eq!(event3.tags.len(), 0);
 
         // Test DCBQueryItem builder
-        let query_item = DCBQueryItem::new()
+        let query_item = DcbQueryItem::new()
             .types(["type1", "type2"])
             .tags(["tagA", "tagB"]);
         assert_eq!(query_item.types.len(), 2);
         assert_eq!(query_item.tags.len(), 2);
 
         // Test DCBQuery builder
-        let query = DCBQuery::new().item(query_item);
+        let query = DcbQuery::new().item(query_item);
         assert_eq!(query.items.len(), 1);
 
         println!("\nAll builder API tests passed!");

--- a/umadb-dcb/src/lib.rs
+++ b/umadb-dcb/src/lib.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 pub trait DcbEventStoreSync {
     /// Reads events from the store based on the provided query and constraints
     ///
-    /// Returns a DCBReadResponseSync that provides an iterator over all events,
+    /// Returns a `DcbReadResponseSync` that provides an iterator over all events,
     /// unless 'from' is given then only those with position greater than 'after',
     /// and unless any query items are given, then only those that match at least one
     /// query item. An event matches a query item if its type is in the item types or
@@ -28,7 +28,7 @@ pub trait DcbEventStoreSync {
         subscribe: bool, // Deprecated - remove in v1.0.
     ) -> DcbResult<Box<dyn DcbReadResponseSync + Send + 'static>>;
 
-    /// Reads events from the store and returns them as a tuple of (Vec<DCBSequencedEvent>, Option<u64>)
+    /// Reads events from the store and returns them as a tuple of `(Vec<DcbSequencedEvent>, Option<u64>)`
     fn read_with_head(
         &self,
         query: Option<DcbQuery>,
@@ -42,7 +42,7 @@ pub trait DcbEventStoreSync {
 
     /// Returns the current head position of the event store, or None if empty
     ///
-    /// Returns the value of last_committed_position, or None if last_committed_position is zero
+    /// Returns the value of `last_committed_position`, or `None` if `last_committed_position` is zero
     fn head(&self) -> DcbResult<Option<u64>>;
 
     /// Returns the greatest recorded upstream position for a tracking source, if any
@@ -85,7 +85,7 @@ pub trait DcbSubscriptionSync: Iterator<Item = DcbResult<DcbSequencedEvent>> + S
 pub trait DcbEventStoreAsync: Send + Sync {
     /// Reads events from the store based on the provided query and constraints
     ///
-    /// Returns a DCBReadResponseSync that provides an iterator over all events,
+    /// Returns a `DcbReadResponseSync` that provides an iterator over all events,
     /// unless 'after' is given then only those with position greater than 'after',
     /// and unless any query items are given, then only those that match at least one
     /// query item. An event matches a query item if its type is in the item types or
@@ -99,7 +99,7 @@ pub trait DcbEventStoreAsync: Send + Sync {
         subscribe: bool,
     ) -> DcbResult<Box<dyn DcbReadResponseAsync + Send + 'static>>;
 
-    /// Reads events from the store and returns them as a tuple of (Vec<DCBSequencedEvent>, Option<u64>)
+    /// Reads events from the store and returns them as a tuple of `(Vec<DcbSequencedEvent>, Option<u64>)`
     async fn read_with_head<'a>(
         &'a self,
         query: Option<DcbQuery>,

--- a/umadb-proto/src/lib.rs
+++ b/umadb-proto/src/lib.rs
@@ -2,7 +2,7 @@ use prost::Message;
 use prost::bytes::Bytes;
 use tonic::{Code, Status};
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBQuery, DCBQueryItem, DCBResult, DCBSequencedEvent,
+    DcbAppendCondition, DdbError, DcbEvent, DcbQuery, DcbQueryItem, DcbResult, DcbSequencedEvent,
     TrackingInfo,
 };
 use uuid::Uuid;
@@ -32,24 +32,24 @@ impl From<TrackingInfo> for v1::TrackingInfo {
     }
 }
 
-impl TryFrom<v1::Event> for DCBEvent {
-    type Error = DCBError;
+impl TryFrom<v1::Event> for DcbEvent {
+    type Error = DdbError;
 
-    fn try_from(proto: v1::Event) -> DCBResult<Self> {
+    fn try_from(proto: v1::Event) -> DcbResult<Self> {
         let uuid = if proto.uuid.is_empty() {
             None
         } else {
             match Uuid::parse_str(&proto.uuid) {
                 Ok(uuid) => Some(uuid),
                 Err(_) => {
-                    return Err(DCBError::DeserializationError(
+                    return Err(DdbError::DeserializationError(
                         "Invalid UUID in Event".to_string(),
                     ));
                 }
             }
         };
 
-        Ok(DCBEvent {
+        Ok(DcbEvent {
             event_type: proto.event_type,
             tags: proto.tags,
             data: proto.data,
@@ -58,8 +58,8 @@ impl TryFrom<v1::Event> for DCBEvent {
     }
 }
 
-impl From<DCBEvent> for v1::Event {
-    fn from(event: DCBEvent) -> Self {
+impl From<DcbEvent> for v1::Event {
+    fn from(event: DcbEvent) -> Self {
         v1::Event {
             event_type: event.event_type,
             tags: event.tags,
@@ -69,17 +69,17 @@ impl From<DCBEvent> for v1::Event {
     }
 }
 
-impl From<v1::QueryItem> for DCBQueryItem {
+impl From<v1::QueryItem> for DcbQueryItem {
     fn from(proto: v1::QueryItem) -> Self {
-        DCBQueryItem {
+        DcbQueryItem {
             types: proto.types,
             tags: proto.tags,
         }
     }
 }
 
-impl From<DCBQueryItem> for v1::QueryItem {
-    fn from(item: DCBQueryItem) -> Self {
+impl From<DcbQueryItem> for v1::QueryItem {
+    fn from(item: DcbQueryItem) -> Self {
         v1::QueryItem {
             types: item.types,
             tags: item.tags,
@@ -87,35 +87,35 @@ impl From<DCBQueryItem> for v1::QueryItem {
     }
 }
 
-impl From<v1::Query> for DCBQuery {
+impl From<v1::Query> for DcbQuery {
     fn from(proto: v1::Query) -> Self {
-        DCBQuery {
+        DcbQuery {
             items: proto.items.into_iter().map(|item| item.into()).collect(),
         }
     }
 }
 
-impl From<DCBQuery> for v1::Query {
-    fn from(query: DCBQuery) -> Self {
+impl From<DcbQuery> for v1::Query {
+    fn from(query: DcbQuery) -> Self {
         v1::Query {
             items: query.items.into_iter().map(|item| item.into()).collect(),
         }
     }
 }
 
-impl From<v1::AppendCondition> for DCBAppendCondition {
+impl From<v1::AppendCondition> for DcbAppendCondition {
     fn from(proto: v1::AppendCondition) -> Self {
-        DCBAppendCondition {
+        DcbAppendCondition {
             fail_if_events_match: proto
                 .fail_if_events_match
-                .map_or_else(DCBQuery::default, |q| q.into()),
+                .map_or_else(DcbQuery::default, |q| q.into()),
             after: proto.after,
         }
     }
 }
 
-impl From<DCBSequencedEvent> for v1::SequencedEvent {
-    fn from(event: DCBSequencedEvent) -> Self {
+impl From<DcbSequencedEvent> for v1::SequencedEvent {
+    fn from(event: DcbSequencedEvent) -> Self {
         v1::SequencedEvent {
             position: event.position,
             event: Some(event.event.into()),
@@ -124,31 +124,31 @@ impl From<DCBSequencedEvent> for v1::SequencedEvent {
 }
 
 // Helper: map DCBError -> tonic::Status with structured details
-pub fn status_from_dcb_error(e: DCBError) -> Status {
+pub fn status_from_dcb_error(e: DdbError) -> Status {
     let (code, error_type) = match e {
-        DCBError::AuthenticationError(_) => (
+        DdbError::AuthenticationError(_) => (
             Code::Unauthenticated,
             v1::error_response::ErrorType::Authentication as i32,
         ),
-        DCBError::InvalidArgument(_) => (
+        DdbError::InvalidArgument(_) => (
             Code::InvalidArgument,
             v1::error_response::ErrorType::InvalidArgument as i32,
         ),
-        DCBError::IntegrityError(_) => (
+        DdbError::IntegrityError(_) => (
             Code::FailedPrecondition,
             v1::error_response::ErrorType::Integrity as i32,
         ),
-        DCBError::Corruption(_)
-        | DCBError::DatabaseCorrupted(_)
-        | DCBError::DeserializationError(_) => (
+        DdbError::Corruption(_)
+        | DdbError::DatabaseCorrupted(_)
+        | DdbError::DeserializationError(_) => (
             Code::DataLoss,
             v1::error_response::ErrorType::Corruption as i32,
         ),
-        DCBError::SerializationError(_) => (
+        DdbError::SerializationError(_) => (
             Code::InvalidArgument,
             v1::error_response::ErrorType::Serialization as i32,
         ),
-        DCBError::InternalError(_) => (
+        DdbError::InternalError(_) => (
             Code::Internal,
             v1::error_response::ErrorType::Internal as i32,
         ),
@@ -164,7 +164,7 @@ pub fn status_from_dcb_error(e: DCBError) -> Status {
 }
 
 // Helper: map tonic::Status -> DCBError by decoding details
-pub fn dcb_error_from_status(status: Status) -> DCBError {
+pub fn dcb_error_from_status(status: Status) -> DdbError {
     let details = status.details();
     // Try to decode ErrorResponse directly from details
     if !details.is_empty()
@@ -172,33 +172,33 @@ pub fn dcb_error_from_status(status: Status) -> DCBError {
     {
         return match err.error_type {
             x if x == v1::error_response::ErrorType::Authentication as i32 => {
-                DCBError::AuthenticationError(err.message)
+                DdbError::AuthenticationError(err.message)
             }
             x if x == v1::error_response::ErrorType::InvalidArgument as i32 => {
-                DCBError::InvalidArgument(err.message)
+                DdbError::InvalidArgument(err.message)
             }
             x if x == v1::error_response::ErrorType::Integrity as i32 => {
-                DCBError::IntegrityError(err.message)
+                DdbError::IntegrityError(err.message)
             }
             x if x == v1::error_response::ErrorType::Corruption as i32 => {
-                DCBError::Corruption(err.message)
+                DdbError::Corruption(err.message)
             }
             x if x == v1::error_response::ErrorType::Serialization as i32 => {
-                DCBError::SerializationError(err.message)
+                DdbError::SerializationError(err.message)
             }
             x if x == v1::error_response::ErrorType::Internal as i32 => {
-                DCBError::InternalError(err.message)
+                DdbError::InternalError(err.message)
             }
-            _ => DCBError::Io(std::io::Error::other(err.message)),
+            _ => DdbError::Io(std::io::Error::other(err.message)),
         };
     }
     // Fallback: infer from gRPC code
     match status.code() {
-        Code::Unauthenticated => DCBError::AuthenticationError(status.message().to_string()),
-        Code::InvalidArgument => DCBError::InvalidArgument(status.message().to_string()),
-        Code::FailedPrecondition => DCBError::IntegrityError(status.message().to_string()),
-        Code::DataLoss => DCBError::Corruption(status.message().to_string()),
-        Code::Internal => DCBError::InternalError(status.message().to_string()),
-        _ => DCBError::Io(std::io::Error::other(format!("gRPC error: {}", status))),
+        Code::Unauthenticated => DdbError::AuthenticationError(status.message().to_string()),
+        Code::InvalidArgument => DdbError::InvalidArgument(status.message().to_string()),
+        Code::FailedPrecondition => DdbError::IntegrityError(status.message().to_string()),
+        Code::DataLoss => DdbError::Corruption(status.message().to_string()),
+        Code::Internal => DdbError::InternalError(status.message().to_string()),
+        _ => DdbError::Io(std::io::Error::other(format!("gRPC error: {}", status))),
     }
 }

--- a/umadb-proto/src/lib.rs
+++ b/umadb-proto/src/lib.rs
@@ -2,7 +2,7 @@ use prost::Message;
 use prost::bytes::Bytes;
 use tonic::{Code, Status};
 use umadb_dcb::{
-    DcbAppendCondition, DdbError, DcbEvent, DcbQuery, DcbQueryItem, DcbResult, DcbSequencedEvent,
+    DcbAppendCondition, DcbError, DcbEvent, DcbQuery, DcbQueryItem, DcbResult, DcbSequencedEvent,
     TrackingInfo,
 };
 use uuid::Uuid;
@@ -33,7 +33,7 @@ impl From<TrackingInfo> for v1::TrackingInfo {
 }
 
 impl TryFrom<v1::Event> for DcbEvent {
-    type Error = DdbError;
+    type Error = DcbError;
 
     fn try_from(proto: v1::Event) -> DcbResult<Self> {
         let uuid = if proto.uuid.is_empty() {
@@ -42,7 +42,7 @@ impl TryFrom<v1::Event> for DcbEvent {
             match Uuid::parse_str(&proto.uuid) {
                 Ok(uuid) => Some(uuid),
                 Err(_) => {
-                    return Err(DdbError::DeserializationError(
+                    return Err(DcbError::DeserializationError(
                         "Invalid UUID in Event".to_string(),
                     ));
                 }
@@ -124,31 +124,31 @@ impl From<DcbSequencedEvent> for v1::SequencedEvent {
 }
 
 // Helper: map DCBError -> tonic::Status with structured details
-pub fn status_from_dcb_error(e: DdbError) -> Status {
+pub fn status_from_dcb_error(e: DcbError) -> Status {
     let (code, error_type) = match e {
-        DdbError::AuthenticationError(_) => (
+        DcbError::AuthenticationError(_) => (
             Code::Unauthenticated,
             v1::error_response::ErrorType::Authentication as i32,
         ),
-        DdbError::InvalidArgument(_) => (
+        DcbError::InvalidArgument(_) => (
             Code::InvalidArgument,
             v1::error_response::ErrorType::InvalidArgument as i32,
         ),
-        DdbError::IntegrityError(_) => (
+        DcbError::IntegrityError(_) => (
             Code::FailedPrecondition,
             v1::error_response::ErrorType::Integrity as i32,
         ),
-        DdbError::Corruption(_)
-        | DdbError::DatabaseCorrupted(_)
-        | DdbError::DeserializationError(_) => (
+        DcbError::Corruption(_)
+        | DcbError::DatabaseCorrupted(_)
+        | DcbError::DeserializationError(_) => (
             Code::DataLoss,
             v1::error_response::ErrorType::Corruption as i32,
         ),
-        DdbError::SerializationError(_) => (
+        DcbError::SerializationError(_) => (
             Code::InvalidArgument,
             v1::error_response::ErrorType::Serialization as i32,
         ),
-        DdbError::InternalError(_) => (
+        DcbError::InternalError(_) => (
             Code::Internal,
             v1::error_response::ErrorType::Internal as i32,
         ),
@@ -164,7 +164,7 @@ pub fn status_from_dcb_error(e: DdbError) -> Status {
 }
 
 // Helper: map tonic::Status -> DCBError by decoding details
-pub fn dcb_error_from_status(status: Status) -> DdbError {
+pub fn dcb_error_from_status(status: Status) -> DcbError {
     let details = status.details();
     // Try to decode ErrorResponse directly from details
     if !details.is_empty()
@@ -172,33 +172,33 @@ pub fn dcb_error_from_status(status: Status) -> DdbError {
     {
         return match err.error_type {
             x if x == v1::error_response::ErrorType::Authentication as i32 => {
-                DdbError::AuthenticationError(err.message)
+                DcbError::AuthenticationError(err.message)
             }
             x if x == v1::error_response::ErrorType::InvalidArgument as i32 => {
-                DdbError::InvalidArgument(err.message)
+                DcbError::InvalidArgument(err.message)
             }
             x if x == v1::error_response::ErrorType::Integrity as i32 => {
-                DdbError::IntegrityError(err.message)
+                DcbError::IntegrityError(err.message)
             }
             x if x == v1::error_response::ErrorType::Corruption as i32 => {
-                DdbError::Corruption(err.message)
+                DcbError::Corruption(err.message)
             }
             x if x == v1::error_response::ErrorType::Serialization as i32 => {
-                DdbError::SerializationError(err.message)
+                DcbError::SerializationError(err.message)
             }
             x if x == v1::error_response::ErrorType::Internal as i32 => {
-                DdbError::InternalError(err.message)
+                DcbError::InternalError(err.message)
             }
-            _ => DdbError::Io(std::io::Error::other(err.message)),
+            _ => DcbError::Io(std::io::Error::other(err.message)),
         };
     }
     // Fallback: infer from gRPC code
     match status.code() {
-        Code::Unauthenticated => DdbError::AuthenticationError(status.message().to_string()),
-        Code::InvalidArgument => DdbError::InvalidArgument(status.message().to_string()),
-        Code::FailedPrecondition => DdbError::IntegrityError(status.message().to_string()),
-        Code::DataLoss => DdbError::Corruption(status.message().to_string()),
-        Code::Internal => DdbError::InternalError(status.message().to_string()),
-        _ => DdbError::Io(std::io::Error::other(format!("gRPC error: {}", status))),
+        Code::Unauthenticated => DcbError::AuthenticationError(status.message().to_string()),
+        Code::InvalidArgument => DcbError::InvalidArgument(status.message().to_string()),
+        Code::FailedPrecondition => DcbError::IntegrityError(status.message().to_string()),
+        Code::DataLoss => DcbError::Corruption(status.message().to_string()),
+        Code::Internal => DcbError::InternalError(status.message().to_string()),
+        _ => DcbError::Io(std::io::Error::other(format!("gRPC error: {}", status))),
     }
 }

--- a/umadb-python/src/lib.rs
+++ b/umadb-python/src/lib.rs
@@ -9,7 +9,7 @@ use pyo3_stub_gen::derive::*;
 use std::sync::{Arc, Mutex};
 use umadb_client::{SyncUmaDBClient, UmaDBClient, trigger_cancel};
 use umadb_dcb::{
-    DcbQuery, DcbQueryItem, DcbSequencedEvent, DcbAppendCondition, DcbEvent, DcbEventStoreSync,
+    DcbAppendCondition, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, DcbSequencedEvent,
     DdbError, TrackingInfo,
 };
 use uuid::Uuid;
@@ -21,7 +21,7 @@ create_exception!(umadb, TransportError, PyRuntimeError);
 create_exception!(umadb, CorruptionError, PyRuntimeError);
 create_exception!(umadb, AuthenticationError, PyPermissionError);
 
-/// Convert DCBError to Python exception
+/// Convert `DcbError` to Python exception
 fn dcb_error_to_py_err(err: DdbError) -> PyErr {
     match err {
         DdbError::InvalidArgument(msg) => PyValueError::new_err(msg),
@@ -34,7 +34,7 @@ fn dcb_error_to_py_err(err: DdbError) -> PyErr {
     }
 }
 
-/// Python wrapper for DCBEvent
+/// Python wrapper for `DcbEvent`
 #[gen_stub_pyclass]
 #[pyclass(name = "Event")]
 #[derive(Clone)]
@@ -103,7 +103,7 @@ impl PyEvent {
     }
 }
 
-/// Python wrapper for DCBSequencedEvent
+/// Python wrapper for `DcbSequencedEvent`
 #[gen_stub_pyclass]
 #[pyclass(name = "SequencedEvent")]
 pub struct PySequencedEvent {
@@ -168,7 +168,7 @@ impl PySequencedEvent {
     }
 }
 
-/// Python wrapper for DCBQueryItem
+/// Python wrapper for `DcbQueryItem`
 #[gen_stub_pyclass]
 #[pyclass(name = "QueryItem")]
 #[derive(Clone)]
@@ -198,7 +198,7 @@ impl PyQueryItem {
     }
 }
 
-/// Python wrapper for DCBQuery
+/// Python wrapper for `DcbQuery`
 #[gen_stub_pyclass]
 #[pyclass(name = "Query")]
 #[derive(Clone)]
@@ -228,7 +228,7 @@ impl PyQuery {
     }
 }
 
-/// Python wrapper for DCBAppendCondition
+/// Python wrapper for `DcbAppendCondition`
 #[gen_stub_pyclass]
 #[pyclass(name = "AppendCondition")]
 #[derive(Clone)]

--- a/umadb-python/src/lib.rs
+++ b/umadb-python/src/lib.rs
@@ -9,8 +9,8 @@ use pyo3_stub_gen::derive::*;
 use std::sync::{Arc, Mutex};
 use umadb_client::{SyncUmaDBClient, UmaDBClient, trigger_cancel};
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBEventStoreSync, DCBQuery, DCBQueryItem,
-    DCBSequencedEvent, TrackingInfo,
+    DcbQuery, DcbQueryItem, DcbSequencedEvent, DcbAppendCondition, DcbEvent, DcbEventStoreSync,
+    DdbError, TrackingInfo,
 };
 use uuid::Uuid;
 
@@ -22,14 +22,14 @@ create_exception!(umadb, CorruptionError, PyRuntimeError);
 create_exception!(umadb, AuthenticationError, PyPermissionError);
 
 /// Convert DCBError to Python exception
-fn dcb_error_to_py_err(err: DCBError) -> PyErr {
+fn dcb_error_to_py_err(err: DdbError) -> PyErr {
     match err {
-        DCBError::InvalidArgument(msg) => PyValueError::new_err(msg),
-        DCBError::IntegrityError(msg) => IntegrityError::new_err(msg),
-        DCBError::TransportError(msg) => TransportError::new_err(msg),
-        DCBError::Corruption(msg) => CorruptionError::new_err(msg),
-        DCBError::CancelledByUser() => PyKeyboardInterrupt::new_err(()),
-        DCBError::AuthenticationError(msg) => AuthenticationError::new_err(msg),
+        DdbError::InvalidArgument(msg) => PyValueError::new_err(msg),
+        DdbError::IntegrityError(msg) => IntegrityError::new_err(msg),
+        DdbError::TransportError(msg) => TransportError::new_err(msg),
+        DdbError::Corruption(msg) => CorruptionError::new_err(msg),
+        DdbError::CancelledByUser() => PyKeyboardInterrupt::new_err(()),
+        DdbError::AuthenticationError(msg) => AuthenticationError::new_err(msg),
         other => PyException::new_err(format!("{}", other)),
     }
 }
@@ -39,7 +39,7 @@ fn dcb_error_to_py_err(err: DCBError) -> PyErr {
 #[pyclass(name = "Event")]
 #[derive(Clone)]
 pub struct PyEvent {
-    inner: DCBEvent,
+    inner: DcbEvent,
 }
 
 #[gen_stub_pymethods]
@@ -63,7 +63,7 @@ impl PyEvent {
         };
 
         Ok(PyEvent {
-            inner: DCBEvent {
+            inner: DcbEvent {
                 event_type,
                 data,
                 tags: tags.unwrap_or_default(),
@@ -107,7 +107,7 @@ impl PyEvent {
 #[gen_stub_pyclass]
 #[pyclass(name = "SequencedEvent")]
 pub struct PySequencedEvent {
-    inner: DCBSequencedEvent,
+    inner: DcbSequencedEvent,
 }
 
 #[gen_stub_pyclass]
@@ -173,7 +173,7 @@ impl PySequencedEvent {
 #[pyclass(name = "QueryItem")]
 #[derive(Clone)]
 pub struct PyQueryItem {
-    inner: DCBQueryItem,
+    inner: DcbQueryItem,
 }
 
 #[gen_stub_pymethods]
@@ -183,7 +183,7 @@ impl PyQueryItem {
     #[pyo3(signature = (types=None, tags=None))]
     fn new(types: Option<Vec<String>>, tags: Option<Vec<String>>) -> Self {
         PyQueryItem {
-            inner: DCBQueryItem {
+            inner: DcbQueryItem {
                 types: types.unwrap_or_default(),
                 tags: tags.unwrap_or_default(),
             },
@@ -203,7 +203,7 @@ impl PyQueryItem {
 #[pyclass(name = "Query")]
 #[derive(Clone)]
 pub struct PyQuery {
-    inner: DCBQuery,
+    inner: DcbQuery,
 }
 
 #[gen_stub_pymethods]
@@ -219,7 +219,7 @@ impl PyQuery {
             .collect();
 
         PyQuery {
-            inner: DCBQuery { items: query_items },
+            inner: DcbQuery { items: query_items },
         }
     }
 
@@ -233,7 +233,7 @@ impl PyQuery {
 #[pyclass(name = "AppendCondition")]
 #[derive(Clone)]
 pub struct PyAppendCondition {
-    inner: DCBAppendCondition,
+    inner: DcbAppendCondition,
 }
 
 #[gen_stub_pymethods]
@@ -243,7 +243,7 @@ impl PyAppendCondition {
     #[pyo3(signature = (fail_if_events_match, after=None))]
     fn new(fail_if_events_match: PyQuery, after: Option<u64>) -> Self {
         PyAppendCondition {
-            inner: DCBAppendCondition {
+            inner: DcbAppendCondition {
                 fail_if_events_match: fail_if_events_match.inner,
                 after,
             },
@@ -259,7 +259,7 @@ impl PyAppendCondition {
 #[gen_stub_pyclass]
 #[pyclass(name = "ReadResponse")]
 pub struct PyReadResponse {
-    inner: Arc<Mutex<Box<dyn umadb_dcb::DCBReadResponseSync + Send + 'static>>>,
+    inner: Arc<Mutex<Box<dyn umadb_dcb::DcbReadResponseSync + Send + 'static>>>,
 }
 
 #[gen_stub_pymethods()]
@@ -331,7 +331,7 @@ impl PyReadResponse {
 #[gen_stub_pyclass]
 #[pyclass(name = "Subscription")]
 pub struct PySubscription {
-    inner: Arc<Mutex<Box<dyn umadb_dcb::DCBSubscriptionSync + Send + 'static>>>,
+    inner: Arc<Mutex<Box<dyn umadb_dcb::DcbSubscriptionSync + Send + 'static>>>,
 }
 
 #[gen_stub_pymethods()]
@@ -515,7 +515,7 @@ impl PyUmaDBClient {
         condition: Option<PyAppendCondition>,
         tracking_info: Option<PyTrackingInfo>,
     ) -> PyResult<u64> {
-        let dcb_events: Vec<DCBEvent> = events.into_iter().map(|e| e.inner).collect();
+        let dcb_events: Vec<DcbEvent> = events.into_iter().map(|e| e.inner).collect();
         let dcb_condition = condition.map(|c| c.inner);
         let dcb_tracking_info = tracking_info.map(|t| t.inner);
         let inner = self.inner.clone();

--- a/umadb-python/src/lib.rs
+++ b/umadb-python/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use umadb_client::{SyncUmaDBClient, UmaDBClient, trigger_cancel};
 use umadb_dcb::{
     DcbAppendCondition, DcbEvent, DcbEventStoreSync, DcbQuery, DcbQueryItem, DcbSequencedEvent,
-    DdbError, TrackingInfo,
+    DcbError, TrackingInfo,
 };
 use uuid::Uuid;
 
@@ -22,14 +22,14 @@ create_exception!(umadb, CorruptionError, PyRuntimeError);
 create_exception!(umadb, AuthenticationError, PyPermissionError);
 
 /// Convert `DcbError` to Python exception
-fn dcb_error_to_py_err(err: DdbError) -> PyErr {
+fn dcb_error_to_py_err(err: DcbError) -> PyErr {
     match err {
-        DdbError::InvalidArgument(msg) => PyValueError::new_err(msg),
-        DdbError::IntegrityError(msg) => IntegrityError::new_err(msg),
-        DdbError::TransportError(msg) => TransportError::new_err(msg),
-        DdbError::Corruption(msg) => CorruptionError::new_err(msg),
-        DdbError::CancelledByUser() => PyKeyboardInterrupt::new_err(()),
-        DdbError::AuthenticationError(msg) => AuthenticationError::new_err(msg),
+        DcbError::InvalidArgument(msg) => PyValueError::new_err(msg),
+        DcbError::IntegrityError(msg) => IntegrityError::new_err(msg),
+        DcbError::TransportError(msg) => TransportError::new_err(msg),
+        DcbError::Corruption(msg) => CorruptionError::new_err(msg),
+        DcbError::CancelledByUser() => PyKeyboardInterrupt::new_err(()),
+        DcbError::AuthenticationError(msg) => AuthenticationError::new_err(msg),
         other => PyException::new_err(format!("{}", other)),
     }
 }

--- a/umadb-server/src/lib.rs
+++ b/umadb-server/src/lib.rs
@@ -16,7 +16,7 @@ use umadb_core::db::{
 };
 use umadb_core::mvcc::Mvcc;
 use umadb_dcb::{
-    DcbAppendCondition, DcbEvent, DcbQuery, DcbResult, DcbSequencedEvent, DdbError, TrackingInfo,
+    DcbAppendCondition, DcbEvent, DcbQuery, DcbResult, DcbSequencedEvent, DcbError, TrackingInfo,
 };
 
 use tokio::runtime::Runtime;
@@ -280,7 +280,7 @@ async fn start_server_internal<P: AsRef<Path> + Send + 'static>(
     let incoming = match TcpIncoming::bind(addr) {
         Ok(incoming) => incoming,
         Err(err) => {
-            return Err(Box::new(DdbError::InitializationError(format!(
+            return Err(Box::new(DcbError::InitializationError(format!(
                 "failed to bind to address {}: {}",
                 addr, err
             ))));
@@ -393,7 +393,7 @@ impl DcbServer {
                 .map(|s| s == expected_val)
                 .unwrap_or(false);
             if !ok {
-                return Err(status_from_dcb_error(DdbError::AuthenticationError(
+                return Err(status_from_dcb_error(DcbError::AuthenticationError(
                     "missing or invalid API key".to_string(),
                 )));
             }
@@ -830,7 +830,7 @@ impl RequestHandler {
 
                             // Track abort state for non-integrity error within the batch
                             let mut abort_idx: Option<usize> = None;
-                            let mut abort_err: Option<DdbError> = None;
+                            let mut abort_err: Option<DcbError> = None;
 
                             responders.push(response_tx);
                             let result = UmaDB::process_append_request(
@@ -999,7 +999,7 @@ impl RequestHandler {
             limit,
             false,
         )
-        .map_err(|e| DdbError::Corruption(format!("{e}")))?;
+        .map_err(|e| DcbError::Corruption(format!("{e}")))?;
 
         let head = if limit.is_none() {
             if last_committed_position == 0 {
@@ -1018,7 +1018,7 @@ impl RequestHandler {
         let (_, header) = self
             .mvcc
             .get_latest_header()
-            .map_err(|e| DdbError::Corruption(format!("{e}")))?;
+            .map_err(|e| DcbError::Corruption(format!("{e}")))?;
         let last = header.next_position.0.saturating_sub(1);
         if last == 0 { Ok(None) } else { Ok(Some(last)) }
     }
@@ -1079,7 +1079,7 @@ impl RequestHandler {
                             given_condition.clone(),
                             matched,
                         );
-                        return Err(DdbError::IntegrityError(msg));
+                        return Err(DcbError::IntegrityError(msg));
                     }
                     Err(err) => {
                         // Propagate underlying read error
@@ -1120,13 +1120,13 @@ impl RequestHandler {
                     })
                     .await
                     .map_err(|_| {
-                        DdbError::Io(std::io::Error::other(
+                        DcbError::Io(std::io::Error::other(
                             "failed to send append request to EventStore thread",
                         ))
                     })?;
 
                 response_rx.await.map_err(|_| {
-                    DdbError::Io(std::io::Error::other(
+                    DcbError::Io(std::io::Error::other(
                         "failed to receive append response from EventStore thread",
                     ))
                 })?

--- a/umadb-server/src/lib.rs
+++ b/umadb-server/src/lib.rs
@@ -16,7 +16,7 @@ use umadb_core::db::{
 };
 use umadb_core::mvcc::Mvcc;
 use umadb_dcb::{
-    DCBAppendCondition, DCBError, DCBEvent, DCBQuery, DCBResult, DCBSequencedEvent, TrackingInfo,
+    DcbAppendCondition, DcbEvent, DcbQuery, DcbResult, DcbSequencedEvent, DdbError, TrackingInfo,
 };
 
 use tokio::runtime::Runtime;
@@ -280,7 +280,7 @@ async fn start_server_internal<P: AsRef<Path> + Send + 'static>(
     let incoming = match TcpIncoming::bind(addr) {
         Ok(incoming) => incoming,
         Err(err) => {
-            return Err(Box::new(DCBError::InitializationError(format!(
+            return Err(Box::new(DdbError::InitializationError(format!(
                 "failed to bind to address {}: {}",
                 addr, err
             ))));
@@ -292,7 +292,7 @@ async fn start_server_internal<P: AsRef<Path> + Send + 'static>(
     // Create a shutdown broadcast channel for terminating ongoing subscriptions
     let (srv_shutdown_tx, srv_shutdown_rx) = watch::channel(false);
     let dcb_server =
-        match DCBServer::new(path.as_ref().to_owned(), srv_shutdown_rx, api_key.clone()) {
+        match DcbServer::new(path.as_ref().to_owned(), srv_shutdown_rx, api_key.clone()) {
             Ok(server) => server,
             Err(err) => {
                 return Err(Box::new(err));
@@ -360,18 +360,18 @@ async fn start_server_internal<P: AsRef<Path> + Send + 'static>(
 }
 
 // gRPC server implementation
-pub struct DCBServer {
+pub struct DcbServer {
     pub(crate) request_handler: RequestHandler,
     shutdown_watch_rx: watch::Receiver<bool>,
     api_key: Option<String>,
 }
 
-impl DCBServer {
+impl DcbServer {
     pub fn new<P: AsRef<Path> + Send + 'static>(
         path: P,
         shutdown_rx: watch::Receiver<bool>,
         api_key: Option<String>,
-    ) -> DCBResult<Self> {
+    ) -> DcbResult<Self> {
         let command_handler = RequestHandler::new(path)?;
         Ok(Self {
             request_handler: command_handler,
@@ -393,7 +393,7 @@ impl DCBServer {
                 .map(|s| s == expected_val)
                 .unwrap_or(false);
             if !ok {
-                return Err(status_from_dcb_error(DCBError::AuthenticationError(
+                return Err(status_from_dcb_error(DdbError::AuthenticationError(
                     "missing or invalid API key".to_string(),
                 )));
             }
@@ -403,7 +403,7 @@ impl DCBServer {
 }
 
 #[tonic::async_trait]
-impl umadb_proto::v1::dcb_server::Dcb for DCBServer {
+impl umadb_proto::v1::dcb_server::Dcb for DcbServer {
     type ReadStream =
         Pin<Box<dyn Stream<Item = Result<umadb_proto::v1::ReadResponse, Status>> + Send + 'static>>;
     type SubscribeStream = Pin<
@@ -419,7 +419,7 @@ impl umadb_proto::v1::dcb_server::Dcb for DCBServer {
         let read_request = request.into_inner();
 
         // Convert protobuf query to DCB types
-        let mut query: Option<DCBQuery> = read_request.query.map(|q| q.into());
+        let mut query: Option<DcbQuery> = read_request.query.map(|q| q.into());
         let start = read_request.start;
         let backwards = read_request.backwards.unwrap_or(false);
         let limit = read_request.limit;
@@ -595,7 +595,7 @@ impl umadb_proto::v1::dcb_server::Dcb for DCBServer {
         let subscribe_request = request.into_inner();
 
         // Convert protobuf query to DCB types
-        let mut query: Option<DCBQuery> = subscribe_request.query.map(|q| q.into());
+        let mut query: Option<DcbQuery> = subscribe_request.query.map(|q| q.into());
         let after = subscribe_request.after;
         // Cap requested batch size.
         let batch_size = subscribe_request
@@ -691,7 +691,7 @@ impl umadb_proto::v1::dcb_server::Dcb for DCBServer {
         let req = request.into_inner();
 
         // Convert protobuf types to API types
-        let events: Vec<DCBEvent> = match req.events.into_iter().map(|e| e.try_into()).collect() {
+        let events: Vec<DcbEvent> = match req.events.into_iter().map(|e| e.try_into()).collect() {
             Ok(events) => events,
             Err(e) => {
                 return Err(status_from_dcb_error(e));
@@ -752,10 +752,10 @@ impl umadb_proto::v1::dcb_server::Dcb for DCBServer {
 // Message types for communication between the gRPC server and the request handler's writer thread
 enum WriterRequest {
     Append {
-        events: Vec<DCBEvent>,
-        condition: Option<DCBAppendCondition>,
+        events: Vec<DcbEvent>,
+        condition: Option<DcbAppendCondition>,
         tracking_info: Option<TrackingInfo>,
-        response_tx: oneshot::Sender<DCBResult<u64>>,
+        response_tx: oneshot::Sender<DcbResult<u64>>,
     },
     Shutdown,
 }
@@ -768,7 +768,7 @@ struct RequestHandler {
 }
 
 impl RequestHandler {
-    fn new<P: AsRef<Path> + Send + 'static>(path: P) -> DCBResult<Self> {
+    fn new<P: AsRef<Path> + Send + 'static>(path: P) -> DcbResult<Self> {
         // Create a channel for sending requests to the writer thread
         let (request_tx, mut request_rx) = mpsc::channel::<WriterRequest>(1024);
 
@@ -825,12 +825,12 @@ impl RequestHandler {
                                 }
                             };
 
-                            let mut responders: Vec<oneshot::Sender<DCBResult<u64>>> = Vec::new();
-                            let mut results: Vec<DCBResult<u64>> = Vec::new();
+                            let mut responders: Vec<oneshot::Sender<DcbResult<u64>>> = Vec::new();
+                            let mut results: Vec<DcbResult<u64>> = Vec::new();
 
                             // Track abort state for non-integrity error within the batch
                             let mut abort_idx: Option<usize> = None;
-                            let mut abort_err: Option<DCBError> = None;
+                            let mut abort_err: Option<DdbError> = None;
 
                             responders.push(response_tx);
                             let result = UmaDB::process_append_request(
@@ -977,15 +977,15 @@ impl RequestHandler {
 
     async fn read(
         &self,
-        query: Option<DCBQuery>,
+        query: Option<DcbQuery>,
         start: Option<u64>,
         backwards: bool,
         limit: Option<u32>,
-    ) -> DCBResult<(Vec<DCBSequencedEvent>, Option<u64>)> {
+    ) -> DcbResult<(Vec<DcbSequencedEvent>, Option<u64>)> {
         let reader = self.mvcc.reader()?;
         let last_committed_position = reader.next_position.0.saturating_sub(1);
 
-        let q = query.unwrap_or(DCBQuery { items: vec![] });
+        let q = query.unwrap_or(DcbQuery { items: vec![] });
         let start_position = start.map(Position);
 
         let events = read_conditional(
@@ -999,7 +999,7 @@ impl RequestHandler {
             limit,
             false,
         )
-        .map_err(|e| DCBError::Corruption(format!("{e}")))?;
+        .map_err(|e| DdbError::Corruption(format!("{e}")))?;
 
         let head = if limit.is_none() {
             if last_committed_position == 0 {
@@ -1014,26 +1014,26 @@ impl RequestHandler {
         Ok((events, head))
     }
 
-    async fn head(&self) -> DCBResult<Option<u64>> {
+    async fn head(&self) -> DcbResult<Option<u64>> {
         let (_, header) = self
             .mvcc
             .get_latest_header()
-            .map_err(|e| DCBError::Corruption(format!("{e}")))?;
+            .map_err(|e| DdbError::Corruption(format!("{e}")))?;
         let last = header.next_position.0.saturating_sub(1);
         if last == 0 { Ok(None) } else { Ok(Some(last)) }
     }
 
-    async fn get_tracking_info(&self, source: String) -> DCBResult<Option<u64>> {
+    async fn get_tracking_info(&self, source: String) -> DcbResult<Option<u64>> {
         let db = UmaDB::from_arc(self.mvcc.clone());
         db.get_tracking_info(&source)
     }
 
     pub async fn append(
         &self,
-        events: Vec<DCBEvent>,
-        condition: Option<DCBAppendCondition>,
+        events: Vec<DcbEvent>,
+        condition: Option<DcbAppendCondition>,
         tracking_info: Option<TrackingInfo>,
-    ) -> DCBResult<u64> {
+    ) -> DcbResult<u64> {
         // Concurrent pre-check of the given condition using a reader in a blocking thread.
         let pre_append_decision = if let Some(mut given_condition) = condition {
             let reader = self.mvcc.reader()?;
@@ -1079,7 +1079,7 @@ impl RequestHandler {
                             given_condition.clone(),
                             matched,
                         );
-                        return Err(DCBError::IntegrityError(msg));
+                        return Err(DdbError::IntegrityError(msg));
                     }
                     Err(err) => {
                         // Propagate underlying read error
@@ -1120,13 +1120,13 @@ impl RequestHandler {
                     })
                     .await
                     .map_err(|_| {
-                        DCBError::Io(std::io::Error::other(
+                        DdbError::Io(std::io::Error::other(
                             "failed to send append request to EventStore thread",
                         ))
                     })?;
 
                 response_rx.await.map_err(|_| {
-                    DCBError::Io(std::io::Error::other(
+                    DdbError::Io(std::io::Error::other(
                         "failed to receive append response from EventStore thread",
                     ))
                 })?
@@ -1158,7 +1158,7 @@ impl Clone for RequestHandler {
 #[derive(Debug)]
 enum PreAppendDecision {
     /// Proceed with this (possibly adjusted) condition
-    UseCondition(Option<DCBAppendCondition>),
+    UseCondition(Option<DcbAppendCondition>),
     /// Skip append operation because the request was idempotent; return last recorded position
     AlreadyAppended(u64),
 }

--- a/umadb-server/src/lib.rs
+++ b/umadb-server/src/lib.rs
@@ -83,7 +83,7 @@ where
             if let Some(final_uri) = new_uri {
                 *req.uri_mut() = final_uri;
             } else {
-                eprintln!("Failed to construct valid URI for path: {}", path);
+                eprintln!("failed to construct valid URI for path: {}", path);
             }
         }
 
@@ -191,7 +191,7 @@ pub async fn start_server_secure_from_files<
     let cert_path_ref = cert_path.as_ref();
     let cert_pem = fs::read(cert_path_ref).map_err(|e| -> Box<dyn std::error::Error> {
         format!(
-            "Failed to open TLS certificate file '{}': {}",
+            "failed to open TLS certificate file '{}': {}",
             cert_path_ref.display(),
             e
         )
@@ -201,7 +201,7 @@ pub async fn start_server_secure_from_files<
     let key_path_ref = key_path.as_ref();
     let key_pem = fs::read(key_path_ref).map_err(|e| -> Box<dyn std::error::Error> {
         format!(
-            "Failed to open TLS key file '{}': {}",
+            "failed to open TLS key file '{}': {}",
             key_path_ref.display(),
             e
         )
@@ -249,7 +249,7 @@ pub async fn start_server_secure_from_files_with_api_key<
     let cert_path_ref = cert_path.as_ref();
     let cert_pem = fs::read(cert_path_ref).map_err(|e| -> Box<dyn std::error::Error> {
         format!(
-            "Failed to open TLS certificate file '{}': {}",
+            "failed to open TLS certificate file '{}': {}",
             cert_path_ref.display(),
             e
         )
@@ -259,7 +259,7 @@ pub async fn start_server_secure_from_files_with_api_key<
     let key_path_ref = key_path.as_ref();
     let key_pem = fs::read(key_path_ref).map_err(|e| -> Box<dyn std::error::Error> {
         format!(
-            "Failed to open TLS key file '{}': {}",
+            "failed to open TLS key file '{}': {}",
             key_path_ref.display(),
             e
         )
@@ -281,7 +281,7 @@ async fn start_server_internal<P: AsRef<Path> + Send + 'static>(
         Ok(incoming) => incoming,
         Err(err) => {
             return Err(Box::new(DCBError::InitializationError(format!(
-                "Failed to bind to address {}: {}",
+                "failed to bind to address {}: {}",
                 addr, err
             ))));
         }
@@ -1121,13 +1121,13 @@ impl RequestHandler {
                     .await
                     .map_err(|_| {
                         DCBError::Io(std::io::Error::other(
-                            "Failed to send append request to EventStore thread",
+                            "failed to send append request to EventStore thread",
                         ))
                     })?;
 
                 response_rx.await.map_err(|_| {
                     DCBError::Io(std::io::Error::other(
-                        "Failed to receive append response from EventStore thread",
+                        "failed to receive append response from EventStore thread",
                     ))
                 })?
             }

--- a/umadb-tools/src/bin/umadb-check.rs
+++ b/umadb-tools/src/bin/umadb-check.rs
@@ -11,7 +11,7 @@ use umadb_core::tags_tree_nodes::{
     TAG_HASH_LEN, TagsLeafNode, get_tag_key_width, normalize_tag_hash_for_current_width,
     set_tag_key_width,
 };
-use umadb_dcb::{DCBError, DCBEvent, DCBQuery, DCBResult};
+use umadb_dcb::{DdbError, DcbEvent, DcbQuery, DcbResult};
 
 fn type_name_from_byte(b: u8) -> Option<&'static str> {
     match b {
@@ -87,15 +87,15 @@ fn parse_args() -> Result<Args, String> {
 fn main() {
     if let Err(e) = real_main() {
         match e {
-            DCBError::InternalError(s) => eprintln!("Error: {}", s),
+            DdbError::InternalError(s) => eprintln!("Error: {}", s),
             other => eprintln!("Error: {}", other),
         }
         std::process::exit(2);
     }
 }
 
-fn real_main() -> DCBResult<()> {
-    let args = parse_args().map_err(DCBError::InternalError)?;
+fn real_main() -> DcbResult<()> {
+    let args = parse_args().map_err(DdbError::InternalError)?;
 
     let path = args.path.unwrap();
     let p = if path.is_dir() {
@@ -106,7 +106,7 @@ fn real_main() -> DCBResult<()> {
 
     // Quick existence check so we can fail fast with a friendly message
     if !p.exists() {
-        return Err(DCBError::InternalError(format!(
+        return Err(DdbError::InternalError(format!(
             "Database file not found: {}",
             p.display()
         )));
@@ -173,10 +173,10 @@ fn real_main() -> DCBResult<()> {
                         let type_str = type_name_from_byte(bytes[0]).unwrap_or("unknown");
                         *counts.entry(type_str).or_insert(0) += 1;
                         let msg = match &err {
-                            DCBError::DeserializationError(_) => {
+                            DdbError::DeserializationError(_) => {
                                 format!("Page {}: {} {:?}", pid, type_str, err)
                             }
-                            DCBError::DatabaseCorrupted(s) => {
+                            DdbError::DatabaseCorrupted(s) => {
                                 format!("Page {}: {} {}", pid, type_str, s)
                             }
                             other => format!("Page {}: {} {:?}", pid, type_str, other),
@@ -289,11 +289,11 @@ fn real_main() -> DCBResult<()> {
                     }
 
                     let msg = match &err {
-                        DCBError::DeserializationError(_) => {
+                        DdbError::DeserializationError(_) => {
                             // Show the variant and message using Debug formatting
                             format!("Page {}: {} {:?}", pid, type_str, err)
                         }
-                        DCBError::DatabaseCorrupted(s) => {
+                        DdbError::DatabaseCorrupted(s) => {
                             // Keep only the human-readable message for corruption
                             format!("Page {}: {} {}", pid, type_str, s)
                         }
@@ -313,7 +313,7 @@ fn real_main() -> DCBResult<()> {
     let reader_file = mvcc.pager.file.clone();
     let file_len = reader_file
         .metadata()
-        .map_err(|e| DCBError::InternalError(format!("Failed to read file metadata: {}", e)))?
+        .map_err(|e| DdbError::InternalError(format!("Failed to read file metadata: {}", e)))?
         .len();
     let page_size_u64 = page_size as u64;
     let mut pid = total_pages; // start at next_page_id
@@ -389,10 +389,10 @@ fn real_main() -> DCBResult<()> {
                     });
                 }
                 let msg = match &err {
-                    DCBError::DeserializationError(_) => {
+                    DdbError::DeserializationError(_) => {
                         format!("Page {}: {} {:?}", pid, type_str, err)
                     }
-                    DCBError::DatabaseCorrupted(s) => format!("Page {}: {} {}", pid, type_str, s),
+                    DdbError::DatabaseCorrupted(s) => format!("Page {}: {} {}", pid, type_str, s),
                     other => format!("Page {}: {} {:?}", pid, type_str, other),
                 };
                 if args.verbose {
@@ -443,7 +443,7 @@ fn real_main() -> DCBResult<()> {
     let mut start = Some(Position(1));
     let mut total_events_read: u64 = 0;
     // Cache of events by position for Stage 4 analysis
-    let mut events_by_position: HashMap<u64, DCBEvent> = HashMap::new();
+    let mut events_by_position: HashMap<u64, DcbEvent> = HashMap::new();
     let empty_dirty: HashMap<PageID, Page> = HashMap::new();
     loop {
         // Read a batch of events sequentially using empty query (all events)
@@ -452,7 +452,7 @@ fn real_main() -> DCBResult<()> {
             &empty_dirty,
             header.events_tree_root_id,
             header.tags_tree_root_id,
-            DCBQuery { items: vec![] },
+            DcbQuery { items: vec![] },
             start,
             false,
             Some(1024),
@@ -503,7 +503,7 @@ fn real_main() -> DCBResult<()> {
                     // Cache event by position for Stage 4
                     events_by_position.insert(
                         ev.position,
-                        DCBEvent {
+                        DcbEvent {
                             event_type: ev.event.event_type.clone(),
                             data: ev.event.data.clone(),
                             tags: ev.event.tags.clone(),
@@ -532,7 +532,7 @@ fn real_main() -> DCBResult<()> {
         &empty_dirty,
         header.events_tree_root_id,
         header.tags_tree_root_id,
-        DCBQuery { items: vec![] },
+        DcbQuery { items: vec![] },
         None,    // no start -> let iterator pick end when backwards
         true,    // backwards: start from the end
         Some(1), // only need the last event
@@ -764,7 +764,7 @@ fn real_main() -> DCBResult<()> {
         fn analyze_entries(
             entries: &Vec<([u8; TAG_HASH_LEN], Vec<u64>)>,
             used_w: usize,
-            events_by_position: &HashMap<u64, DCBEvent>,
+            events_by_position: &HashMap<u64, DcbEvent>,
         ) -> (usize, usize, usize, Vec<String>) {
             let mut total_positions = 0usize;
             let mut pos_with_event = 0usize;
@@ -903,7 +903,7 @@ fn real_main() -> DCBResult<()> {
         println!("Integrity: OK");
         Ok(())
     } else {
-        Err(DCBError::InternalError(
+        Err(DdbError::InternalError(
             "Integrity check failed".to_string(),
         ))
     }

--- a/umadb-tools/src/bin/umadb-check.rs
+++ b/umadb-tools/src/bin/umadb-check.rs
@@ -11,7 +11,7 @@ use umadb_core::tags_tree_nodes::{
     TAG_HASH_LEN, TagsLeafNode, get_tag_key_width, normalize_tag_hash_for_current_width,
     set_tag_key_width,
 };
-use umadb_dcb::{DdbError, DcbEvent, DcbQuery, DcbResult};
+use umadb_dcb::{DcbError, DcbEvent, DcbQuery, DcbResult};
 
 fn type_name_from_byte(b: u8) -> Option<&'static str> {
     match b {
@@ -87,7 +87,7 @@ fn parse_args() -> Result<Args, String> {
 fn main() {
     if let Err(e) = real_main() {
         match e {
-            DdbError::InternalError(s) => eprintln!("Error: {}", s),
+            DcbError::InternalError(s) => eprintln!("Error: {}", s),
             other => eprintln!("Error: {}", other),
         }
         std::process::exit(2);
@@ -95,7 +95,7 @@ fn main() {
 }
 
 fn real_main() -> DcbResult<()> {
-    let args = parse_args().map_err(DdbError::InternalError)?;
+    let args = parse_args().map_err(DcbError::InternalError)?;
 
     let path = args.path.unwrap();
     let p = if path.is_dir() {
@@ -106,7 +106,7 @@ fn real_main() -> DcbResult<()> {
 
     // Quick existence check so we can fail fast with a friendly message
     if !p.exists() {
-        return Err(DdbError::InternalError(format!(
+        return Err(DcbError::InternalError(format!(
             "Database file not found: {}",
             p.display()
         )));
@@ -173,10 +173,10 @@ fn real_main() -> DcbResult<()> {
                         let type_str = type_name_from_byte(bytes[0]).unwrap_or("unknown");
                         *counts.entry(type_str).or_insert(0) += 1;
                         let msg = match &err {
-                            DdbError::DeserializationError(_) => {
+                            DcbError::DeserializationError(_) => {
                                 format!("Page {}: {} {:?}", pid, type_str, err)
                             }
-                            DdbError::DatabaseCorrupted(s) => {
+                            DcbError::DatabaseCorrupted(s) => {
                                 format!("Page {}: {} {}", pid, type_str, s)
                             }
                             other => format!("Page {}: {} {:?}", pid, type_str, other),
@@ -289,11 +289,11 @@ fn real_main() -> DcbResult<()> {
                     }
 
                     let msg = match &err {
-                        DdbError::DeserializationError(_) => {
+                        DcbError::DeserializationError(_) => {
                             // Show the variant and message using Debug formatting
                             format!("Page {}: {} {:?}", pid, type_str, err)
                         }
-                        DdbError::DatabaseCorrupted(s) => {
+                        DcbError::DatabaseCorrupted(s) => {
                             // Keep only the human-readable message for corruption
                             format!("Page {}: {} {}", pid, type_str, s)
                         }
@@ -313,7 +313,7 @@ fn real_main() -> DcbResult<()> {
     let reader_file = mvcc.pager.file.clone();
     let file_len = reader_file
         .metadata()
-        .map_err(|e| DdbError::InternalError(format!("Failed to read file metadata: {}", e)))?
+        .map_err(|e| DcbError::InternalError(format!("Failed to read file metadata: {}", e)))?
         .len();
     let page_size_u64 = page_size as u64;
     let mut pid = total_pages; // start at next_page_id
@@ -389,10 +389,10 @@ fn real_main() -> DcbResult<()> {
                     });
                 }
                 let msg = match &err {
-                    DdbError::DeserializationError(_) => {
+                    DcbError::DeserializationError(_) => {
                         format!("Page {}: {} {:?}", pid, type_str, err)
                     }
-                    DdbError::DatabaseCorrupted(s) => format!("Page {}: {} {}", pid, type_str, s),
+                    DcbError::DatabaseCorrupted(s) => format!("Page {}: {} {}", pid, type_str, s),
                     other => format!("Page {}: {} {:?}", pid, type_str, other),
                 };
                 if args.verbose {
@@ -903,7 +903,7 @@ fn real_main() -> DcbResult<()> {
         println!("Integrity: OK");
         Ok(())
     } else {
-        Err(DdbError::InternalError(
+        Err(DcbError::InternalError(
             "Integrity check failed".to_string(),
         ))
     }


### PR DESCRIPTION
Renames all types starting with `DCB` with `Dcb`, for better compatibility with Rust API guidelines:
https://rust-lang.github.io/api-guidelines/naming.html#naming

> In `UpperCamelCase`, acronyms and contractions of compound words count as one word: use `Uuid` rather than `UUID`, `Usize` rather than `USize` or `Stdin` rather than `StdIn`.

This is somewhat opinionated and umadb would be fine without this change, but I thought I'd share a PR from my fork with the change.

Includes the commit from https://github.com/umadb-io/umadb/pull/14, so that PR should be merged first.